### PR TITLE
feat(ui): add swipe container and update timeline card

### DIFF
--- a/shared/ui/SwipeContainer.tsx
+++ b/shared/ui/SwipeContainer.tsx
@@ -1,0 +1,68 @@
+import React, { useCallback, useRef, useState } from 'react';
+
+export interface SwipeContainerProps {
+  /** Slides to display. Usually `TimelineCard`s. */
+  children: React.ReactNode[];
+}
+
+/**
+ * Basic vertical swipe container.
+ * - Keyboard support with ArrowUp / ArrowDown.
+ * - Touch swipe support.
+ * - Renders only the current slide and \u00b12 siblings for prefetch.
+ */
+export const SwipeContainer: React.FC<SwipeContainerProps> = ({ children }) => {
+  const count = React.Children.count(children);
+  const [index, setIndex] = useState(0);
+  const startY = useRef<number | null>(null);
+
+  const next = useCallback(() => {
+    setIndex((i) => Math.min(count - 1, i + 1));
+  }, [count]);
+
+  const prev = useCallback(() => {
+    setIndex((i) => Math.max(0, i - 1));
+  }, []);
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'ArrowDown') next();
+    if (e.key === 'ArrowUp') prev();
+  };
+
+  const onTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+    startY.current = e.touches[0].clientY;
+  };
+
+  const onTouchEnd = (e: React.TouchEvent<HTMLDivElement>) => {
+    if (startY.current == null) return;
+    const delta = e.changedTouches[0].clientY - startY.current;
+    if (Math.abs(delta) > 50) {
+      if (delta < 0) next();
+      else prev();
+    }
+    startY.current = null;
+  };
+
+  return (
+    <div
+      className="relative h-full overflow-hidden touch-pan-y"
+      tabIndex={0}
+      onKeyDown={onKeyDown}
+      onTouchStart={onTouchStart}
+      onTouchEnd={onTouchEnd}
+    >
+      {React.Children.map(children, (child, i) => {
+        const offset = i - index;
+        if (Math.abs(offset) > 2) return null; // prefetch \u00b12
+        return (
+          <div
+            className="absolute inset-0 transition-transform duration-300"
+            style={{ transform: `translateY(${offset * 100}%)` }}
+          >
+            {child}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/shared/ui/TimelineCard.tsx
+++ b/shared/ui/TimelineCard.tsx
@@ -1,13 +1,25 @@
 import React from 'react';
+import { ZapButton } from './ZapButton';
 
 export interface TimelineCardProps {
+  /** Author or channel name */
+  author: string;
+  /** Video or media content */
   children?: React.ReactNode;
+  /** Called with sat amount when user zaps */
+  onZap?: (amount: number) => void;
 }
 
-export const TimelineCard: React.FC<TimelineCardProps> = ({ children }) => {
+export const TimelineCard: React.FC<TimelineCardProps> = ({ author, children, onZap }) => {
   return (
-    <div className="p-4 rounded border shadow-sm bg-white">
-      {children ?? 'TimelineCard'}
-    </div>
+    <article className="h-[90vh] w-full bg-white rounded-card shadow-sm flex flex-col">
+      <div className="flex-1 flex items-center justify-center bg-gray-200">
+        {children ?? 'Video'}
+      </div>
+      <footer className="p-4 flex items-center justify-between">
+        <span className="font-semibold">{author}</span>
+        {onZap && <ZapButton onZap={onZap} />}
+      </footer>
+    </article>
   );
 };

--- a/shared/ui/index.ts
+++ b/shared/ui/index.ts
@@ -1,0 +1,4 @@
+export * from './TimelineCard';
+export * from './WalletModal';
+export * from './ZapButton';
+export * from './SwipeContainer';


### PR DESCRIPTION
## Summary
- add vertical SwipeContainer with keyboard and touch navigation
- flesh out TimelineCard with author line and optional zap bar
- export ui components from shared/ui index

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688dd54b238c8331ba1c31c5163d8337