### PR TITLE
feat: add video player and skeleton loader

### DIFF
--- a/shared/ui/SkeletonLoader.test.tsx
+++ b/shared/ui/SkeletonLoader.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { SkeletonLoader } from './SkeletonLoader';
+
+describe('SkeletonLoader', () => {
+  it('renders shimmer placeholder', () => {
+    const html = renderToStaticMarkup(<SkeletonLoader />);
+    expect(html).toContain('bg-gray-200');
+    expect(html).toContain('bg-gradient-to-r');
+  });
+});

--- a/shared/ui/SkeletonLoader.tsx
+++ b/shared/ui/SkeletonLoader.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+const shimmerStyle = `
+  @keyframes skeleton-shimmer {
+    100% { transform: translateX(100%); }
+  }
+`;
+
+if (typeof document !== 'undefined' && !document.getElementById('skeleton-loader-style')) {
+  const style = document.createElement('style');
+  style.id = 'skeleton-loader-style';
+  style.textContent = shimmerStyle;
+  document.head.appendChild(style);
+}
+
+export interface SkeletonLoaderProps {
+  className?: string;
+}
+
+/**
+ * SkeletonLoader renders a shimmer animation placeholder used while content
+ * is loading to prevent layout shifts.
+ */
+export const SkeletonLoader: React.FC<SkeletonLoaderProps> = ({ className }) => {
+  return (
+    <div className={`relative overflow-hidden bg-gray-200 ${className ?? ''}`}>
+      <div
+        className="absolute inset-0 -translate-x-full bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200"
+        style={{ animation: 'skeleton-shimmer 1.5s infinite' }}
+      />
+    </div>
+  );
+};

--- a/shared/ui/VideoPlayer.test.tsx
+++ b/shared/ui/VideoPlayer.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { VideoPlayer } from './VideoPlayer';
+
+describe('VideoPlayer', () => {
+  it('is muted by default and uses a blob URL', () => {
+    const html = renderToStaticMarkup(<VideoPlayer />);
+    expect(html).toContain('muted');
+    expect(html).toContain('src="blob:');
+  });
+});

--- a/shared/ui/VideoPlayer.tsx
+++ b/shared/ui/VideoPlayer.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+/**
+ * VideoPlayer renders a video element sourced from a mocked magnet stream.
+ * The mock stream is represented by a blob URL and the video is muted by default
+ * to enable autoplay without user interaction.
+ */
+export const VideoPlayer: React.FC = () => {
+  const [src] = React.useState(() => {
+    const blob = new Blob(['mock magnet stream'], { type: 'video/mp4' });
+    if (typeof URL !== 'undefined' && 'createObjectURL' in URL) {
+      return (URL as any).createObjectURL(blob);
+    }
+    return 'blob:mock-video';
+  });
+
+  return <video className="w-full h-full" src={src} muted controls />;
+};

--- a/shared/ui/index.ts
+++ b/shared/ui/index.ts
@@ -2,3 +2,5 @@ export * from './TimelineCard';
 export * from './WalletModal';
 export * from './ZapButton';
 export * from './SwipeContainer';
+export * from './VideoPlayer';
+export * from './SkeletonLoader';


### PR DESCRIPTION
## Summary
- add VideoPlayer component using blob-backed mock stream and muted playback
- add SkeletonLoader shimmer placeholder and expose via UI index

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dd8e719d883319425999d0104dd83