### PR TITLE
feat: add zap button with balance store

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   "license": "GPL-3.0-or-later",
   "type": "module",
   "dependencies": {
+    "canvas-confetti": "^1.9.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "zod": "^4.0.14"
+    "zod": "^4.0.14",
+    "zustand": "^5.0.7"
   },
   "devDependencies": {
     "@types/node": "^24.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      canvas-confetti:
+        specifier: ^1.9.3
+        version: 1.9.3
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -17,6 +20,9 @@ importers:
       zod:
         specifier: ^4.0.14
         version: 4.0.14
+      zustand:
+        specifier: ^5.0.7
+        version: 5.0.7(@types/react@19.1.9)(react@19.1.1)
     devDependencies:
       '@types/node':
         specifier: ^24.1.0
@@ -352,6 +358,9 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  canvas-confetti@1.9.3:
+    resolution: {integrity: sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==}
+
   chai@5.2.1:
     resolution: {integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==}
     engines: {node: '>=18'}
@@ -583,6 +592,24 @@ packages:
   zod@4.0.14:
     resolution: {integrity: sha512-nGFJTnJN6cM2v9kXL+SOBq3AtjQby3Mv5ySGFof5UGRHrRioSJ5iG680cYNjE/yWk671nROcpPj4hAS8nyLhSw==}
 
+  zustand@5.0.7:
+    resolution: {integrity: sha512-Ot6uqHDW/O2VdYsKLLU8GQu8sCOM1LcoE8RwvLv9uuRT9s6SOHCKs0ZEOhxg+I1Ld+A1Q5lwx+UlKXXUoCZITg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@esbuild/aix-ppc64@0.25.8':
@@ -790,6 +817,8 @@ snapshots:
   assertion-error@2.0.1: {}
 
   cac@6.7.14: {}
+
+  canvas-confetti@1.9.3: {}
 
   chai@5.2.1:
     dependencies:
@@ -1025,3 +1054,8 @@ snapshots:
       stackback: 0.0.2
 
   zod@4.0.14: {}
+
+  zustand@5.0.7(@types/react@19.1.9)(react@19.1.1):
+    optionalDependencies:
+      '@types/react': 19.1.9
+      react: 19.1.1

--- a/shared/ui/BalanceChip.test.tsx
+++ b/shared/ui/BalanceChip.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { BalanceChip } from './BalanceChip';
+import { useBalanceStore } from './balanceStore';
+
+describe('BalanceChip', () => {
+  beforeEach(() => {
+    useBalanceStore.setState({ balance: 0 }, true);
+  });
+
+  it('renders balance and updates on change', () => {
+    const initial = renderToStaticMarkup(<BalanceChip />);
+    expect(initial).toContain('0 sats');
+    useBalanceStore.setState({ balance: 200 }, true);
+    const updated = renderToStaticMarkup(<BalanceChip />);
+    expect(updated).toContain('200 sats');
+  });
+});

--- a/shared/ui/BalanceChip.tsx
+++ b/shared/ui/BalanceChip.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+import { useBalanceStore } from './balanceStore';
+
+export const BalanceChip: React.FC = () => {
+  const balance =
+    typeof window === 'undefined'
+      ? useBalanceStore.getState().balance
+      : useBalanceStore((s) => s.balance);
+  const [animate, setAnimate] = useState(false);
+
+  useEffect(() => {
+    setAnimate(true);
+    const t = setTimeout(() => setAnimate(false), 300);
+    return () => clearTimeout(t);
+  }, [balance]);
+
+  return (
+    <span
+      className={`px-2 py-1 bg-green-200 rounded-full text-sm ${
+        animate ? 'animate-pulse' : ''
+      }`}
+    >
+      {balance} sats
+    </span>
+  );
+};

--- a/shared/ui/ZapButton.test.tsx
+++ b/shared/ui/ZapButton.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ZapButton } from './ZapButton';
+import { useBalanceStore } from './balanceStore';
+
+describe('ZapButton', () => {
+  beforeEach(() => {
+    useBalanceStore.setState({ balance: 0 }, true);
+  });
+
+  it('disables amounts above balance', () => {
+    useBalanceStore.setState({ balance: 50 }, true);
+    const html = renderToStaticMarkup(<ZapButton />);
+    const disabledCount = (html.match(/disabled=""/g) || []).length;
+    expect(disabledCount).toBe(2);
+  });
+
+  it('enables all amounts when balance high enough', () => {
+    useBalanceStore.setState({ balance: 2000 }, true);
+    const html = renderToStaticMarkup(<ZapButton />);
+    expect(html).not.toContain('disabled=""');
+  });
+});

--- a/shared/ui/ZapButton.tsx
+++ b/shared/ui/ZapButton.tsx
@@ -1,25 +1,70 @@
-import React from 'react';
+import React, { useRef } from 'react';
+import { useBalanceStore } from './balanceStore';
 
 export interface ZapButtonProps {
-  onZap: (amount: number) => void;
-  disabled?: boolean;
+  onZap?: (amount: number) => void;
 }
 
 const amounts = [21, 100, 1000];
 
-export const ZapButton: React.FC<ZapButtonProps> = ({ onZap, disabled }) => {
+const ZapOption: React.FC<{ amount: number; onZap?: (amt: number) => void }> = ({ amount, onZap }) => {
+  const balance =
+    typeof window === 'undefined'
+      ? useBalanceStore.getState().balance
+      : useBalanceStore((s) => s.balance);
+  const zap = useBalanceStore.getState().zap;
+  const timer = useRef<NodeJS.Timeout | null>(null);
+  const longPress = useRef(false);
+
+  const promptCustom = () => {
+    if (typeof window === 'undefined') return;
+    const input = window.prompt('Custom zap amount (sats)');
+    const value = Number(input);
+    if (!isNaN(value) && value > 0 && value <= balance) {
+      zap(value);
+      onZap?.(value);
+    }
+  };
+
+  const handlePointerDown = () => {
+    longPress.current = false;
+    timer.current = setTimeout(() => {
+      longPress.current = true;
+      promptCustom();
+    }, 600);
+  };
+
+  const handlePointerUp = () => {
+    if (timer.current) clearTimeout(timer.current);
+    if (!longPress.current) {
+      if (balance >= amount) {
+        zap(amount);
+        onZap?.(amount);
+      }
+    }
+  };
+
+  const handlePointerLeave = () => {
+    if (timer.current) clearTimeout(timer.current);
+  };
+
   return (
-    <div className="flex gap-2">
-      {amounts.map((amt) => (
-        <button
-          key={amt}
-          className="px-2 py-1 bg-purple-600 text-white rounded disabled:opacity-50"
-          disabled={disabled}
-          onClick={() => onZap(amt)}
-        >
-          {amt}
-        </button>
-      ))}
-    </div>
+    <button
+      className="px-2 py-1 bg-purple-600 text-white rounded disabled:opacity-50"
+      disabled={balance < amount}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      onPointerLeave={handlePointerLeave}
+    >
+      {amount}
+    </button>
   );
 };
+
+export const ZapButton: React.FC<ZapButtonProps> = ({ onZap }) => (
+  <div className="flex gap-2">
+    {amounts.map((amt) => (
+      <ZapOption key={amt} amount={amt} onZap={onZap} />
+    ))}
+  </div>
+);

--- a/shared/ui/balanceStore.ts
+++ b/shared/ui/balanceStore.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand';
+
+// trigger simple confetti effect when running in browser
+const triggerConfetti = () => {
+  if (typeof window !== 'undefined') {
+    // lazy-load to avoid SSR issues
+    import('canvas-confetti').then((m) => m.default());
+  }
+};
+
+interface BalanceState {
+  balance: number;
+  setBalance: (balance: number) => void;
+  zap: (amount: number) => void;
+}
+
+export const useBalanceStore = create<BalanceState>((set) => ({
+  balance: 0,
+  setBalance: (balance) => set({ balance }, true),
+  zap: (amount) =>
+    set(
+      (state) => {
+        if (state.balance >= amount) {
+          triggerConfetti();
+          return { balance: state.balance - amount };
+        }
+        return state;
+      },
+      true,
+    ),
+}));

--- a/shared/ui/index.ts
+++ b/shared/ui/index.ts
@@ -4,3 +4,5 @@ export * from './ZapButton';
 export * from './SwipeContainer';
 export * from './VideoPlayer';
 export * from './SkeletonLoader';
+export * from './BalanceChip';
+export * from './balanceStore';


### PR DESCRIPTION
## Summary
- add zustand balance store with confetti trigger
- show dynamic balance chip that animates on changes
- expand ZapButton for quick and custom zaps using store

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688ddad2b0c0833191026373d399963a