### PR TITLE
feat(ui): add infinite timeline swipe

### DIFF
--- a/shared/ui/SwipeContainer.tsx
+++ b/shared/ui/SwipeContainer.tsx
@@ -1,8 +1,10 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 export interface SwipeContainerProps {
   /** Slides to display. Usually `TimelineCard`s. */
   children: React.ReactNode[];
+  /** Notifies when the active slide changes. */
+  onIndexChange?: (index: number) => void;
 }
 
 /**
@@ -11,14 +13,16 @@ export interface SwipeContainerProps {
  * - Touch swipe support.
  * - Renders only the current slide and \u00b12 siblings for prefetch.
  */
-export const SwipeContainer: React.FC<SwipeContainerProps> = ({ children }) => {
-  const count = React.Children.count(children);
+export const SwipeContainer: React.FC<SwipeContainerProps> = ({
+  children,
+  onIndexChange,
+}) => {
   const [index, setIndex] = useState(0);
   const startY = useRef<number | null>(null);
 
   const next = useCallback(() => {
-    setIndex((i) => Math.min(count - 1, i + 1));
-  }, [count]);
+    setIndex((i) => i + 1);
+  }, []);
 
   const prev = useCallback(() => {
     setIndex((i) => Math.max(0, i - 1));
@@ -42,6 +46,10 @@ export const SwipeContainer: React.FC<SwipeContainerProps> = ({ children }) => {
     }
     startY.current = null;
   };
+
+  useEffect(() => {
+    onIndexChange?.(index);
+  }, [index, onIndexChange]);
 
   return (
     <div

--- a/shared/ui/Timeline.tsx
+++ b/shared/ui/Timeline.tsx
@@ -1,0 +1,59 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { SwipeContainer } from './SwipeContainer';
+import { TimelineCard } from './TimelineCard';
+import { BalanceChip } from './BalanceChip';
+
+/**
+ * Demo timeline that renders an infinite list of `TimelineCard`s.
+ * Cards are generated on demand and adjacent clips are prefetched
+ * when the user navigates with swipe or arrow keys.
+ */
+export const Timeline: React.FC = () => {
+  const [cards, setCards] = useState<React.ReactNode[]>([]);
+
+  const ensureCard = useCallback((index: number) => {
+    setCards((prev) => {
+      if (prev[index]) return prev;
+      const next = [...prev];
+      next[index] = (
+        <TimelineCard
+          key={index}
+          author={`Creator ${index}`}
+          onZap={(amt) => console.log('zap', amt)}
+        >
+          <div className="flex h-full items-center justify-center">
+            Clip {index}
+          </div>
+        </TimelineCard>
+      );
+      return next;
+    });
+  }, []);
+
+  const handleIndexChange = useCallback(
+    (i: number) => {
+      ensureCard(i);
+      ensureCard(i + 1); // prefetch next
+    },
+    [ensureCard]
+  );
+
+  useEffect(() => {
+    // initial load
+    ensureCard(0);
+    ensureCard(1);
+  }, [ensureCard]);
+
+  return (
+    <div className="flex h-screen flex-col">
+      <header className="flex justify-end p-2">
+        <BalanceChip />
+      </header>
+      <div className="flex-1">
+        <SwipeContainer onIndexChange={handleIndexChange}>
+          {cards}
+        </SwipeContainer>
+      </div>
+    </div>
+  );
+};

--- a/shared/ui/index.ts
+++ b/shared/ui/index.ts
@@ -17,3 +17,4 @@ export * from './ClipTrimSlider';
 export * from './CaptionTextarea';
 export * from './PublishBtn';
 export * from './TranscodeModal';
+export * from './Timeline';


### PR DESCRIPTION
## Summary
- add index change callback to SwipeContainer so parents can load more slides
- create demo Timeline component that renders TimelineCard list, includes ZapButton and BalanceChip

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688ddfcb60dc833188f809f2fb04aad5