### PR TITLE
feat: add dark mode toggle, storage quota bar and seed backup

### DIFF
--- a/shared/ui/BackupSeedBtn.tsx
+++ b/shared/ui/BackupSeedBtn.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+/** Button to export wallet seed as a text file. */
+export const BackupSeedBtn: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = (
+  props,
+) => {
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    props.onClick?.(e);
+    if (typeof window === 'undefined') return;
+    const seed = localStorage.getItem('walletSeed') ?? '';
+    const blob = new Blob([seed], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'wallet-seed.txt';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <button
+      {...props}
+      onClick={handleClick}
+      className={`px-3 py-1 bg-green-600 text-white rounded ${props.className ?? ''}`}
+    >
+      Backup Seed
+    </button>
+  );
+};

--- a/shared/ui/Nav.tsx
+++ b/shared/ui/Nav.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { WalletModal } from './WalletModal';
+import { ToggleDarkMode } from './ToggleDarkMode';
 
 /** Simple navigation bar that opens the wallet bottom sheet. */
 export const Nav: React.FC = () => {
@@ -8,9 +9,15 @@ export const Nav: React.FC = () => {
   return (
     <nav className="flex items-center justify-between p-2 bg-gray-100">
       <span className="font-bold">CashuCast</span>
-      <button onClick={() => setOpen(true)} className="px-2 py-1 rounded bg-gray-200">
-        Wallet
-      </button>
+      <div className="flex items-center gap-2">
+        <ToggleDarkMode />
+        <button
+          onClick={() => setOpen(true)}
+          className="px-2 py-1 rounded bg-gray-200"
+        >
+          Wallet
+        </button>
+      </div>
       <WalletModal open={open} onOpenChange={setOpen} />
     </nav>
   );

--- a/shared/ui/QuotaBar.tsx
+++ b/shared/ui/QuotaBar.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+/** Progress bar showing used storage quota. */
+export const QuotaBar: React.FC = () => {
+  const [{ usage, quota }, setEstimate] = React.useState({ usage: 0, quota: 0 });
+
+  React.useEffect(() => {
+    let mounted = true;
+    if (navigator?.storage?.estimate) {
+      navigator.storage.estimate().then((res) => {
+        if (mounted) setEstimate({ usage: res.usage ?? 0, quota: res.quota ?? 0 });
+      });
+    }
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const pct = quota > 0 ? Math.min(100, (usage / quota) * 100) : 0;
+
+  return (
+    <div className="space-y-1">
+      <div className="h-2 w-full bg-gray-200 rounded">
+        <div
+          className="h-2 bg-green-500 rounded"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <div className="text-xs text-gray-500">
+        {((usage / 1024) | 0)}KB / {((quota / 1024) | 0)}KB
+      </div>
+    </div>
+  );
+};

--- a/shared/ui/ToggleDarkMode.tsx
+++ b/shared/ui/ToggleDarkMode.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+/** Toggle between light and dark themes and persist choice to localStorage. */
+export const ToggleDarkMode: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = (
+  props,
+) => {
+  const [dark, setDark] = React.useState(() => {
+    if (typeof window === 'undefined') return false;
+    return localStorage.getItem('theme') === 'dark';
+  });
+
+  React.useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.classList.toggle('dark', dark);
+    }
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('theme', dark ? 'dark' : 'light');
+    }
+  }, [dark]);
+
+  return (
+    <button
+      {...props}
+      onClick={(e) => {
+        props.onClick?.(e);
+        setDark((d) => !d);
+      }}
+      className={`px-2 py-1 rounded bg-gray-200 ${props.className ?? ''}`}
+    >
+      {dark ? 'Light Mode' : 'Dark Mode'}
+    </button>
+  );
+};

--- a/shared/ui/WalletModal.tsx
+++ b/shared/ui/WalletModal.tsx
@@ -4,6 +4,8 @@ import { BalanceChip } from './BalanceChip';
 import { MintPicker } from './MintPicker';
 import { RefillBtn } from './RefillBtn';
 import { TxList } from './TxList';
+import { QuotaBar } from './QuotaBar';
+import { BackupSeedBtn } from './BackupSeedBtn';
 
 export interface WalletModalProps {
   open: boolean;
@@ -18,6 +20,8 @@ export const WalletModal: React.FC<WalletModalProps> = ({ open, onOpenChange }) 
         <BalanceChip />
         <MintPicker />
         <RefillBtn />
+        <BackupSeedBtn />
+        <QuotaBar />
         <TxList />
       </div>
     </BottomSheet>

--- a/shared/ui/index.ts
+++ b/shared/ui/index.ts
@@ -24,3 +24,6 @@ export * from './FollowBtn';
 export * from './ZapStats';
 export * from './ProfileGrid';
 export * from './Profile';
+export * from './ToggleDarkMode';
+export * from './QuotaBar';
+export * from './BackupSeedBtn';


### PR DESCRIPTION
## Summary
- add persistent dark mode toggle stored in localStorage
- show storage quota bar from navigator.storage.estimate
- allow exporting wallet seed as a backup file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688de1ccf47c833190fed87576367b09