### PR TITLE
feat: responsive timeline and grid layout

### DIFF
--- a/shared/ui/BottomNav.test.tsx
+++ b/shared/ui/BottomNav.test.tsx
@@ -10,4 +10,9 @@ describe('BottomNav', () => {
     expect(html).toContain('+');
     expect(html).toContain('Profile');
   });
+
+  it('hides on wider screens', () => {
+    const html = renderToStaticMarkup(<BottomNav />);
+    expect(html).toContain('sm:hidden');
+  });
 });

--- a/shared/ui/BottomNav.tsx
+++ b/shared/ui/BottomNav.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-/** Bottom navigation bar that hides on scroll down. */
+/** Bottom navigation bar that hides on scroll down.
+ * Visible only on screens up to 600px wide.
+ */
 export const BottomNav: React.FC = () => {
   const [hidden, setHidden] = React.useState(false);
 
@@ -18,19 +20,11 @@ export const BottomNav: React.FC = () => {
 
   return (
     <nav
-      className={`fixed bottom-0 left-0 right-0 flex justify-around bg-gray-100 p-2 transition-transform duration-300 ${
-        hidden ? 'translate-y-full' : ''
-      }`}
+      className={`fixed bottom-0 left-0 right-0 flex justify-around bg-gray-100 p-2 transition-transform duration-300 sm:hidden ${hidden ? 'translate-y-full' : ''}`}
     >
-      <a href="/" aria-label="Home">
-        Home
-      </a>
-      <a href="/record" aria-label="Record" className="text-2xl">
-        +
-      </a>
-      <a href="/profile" aria-label="Profile">
-        Profile
-      </a>
+      <a href="/" aria-label="Home">Home</a>
+      <a href="/record" aria-label="Record" className="text-2xl">+</a>
+      <a href="/profile" aria-label="Profile">Profile</a>
     </nav>
   );
 };

--- a/shared/ui/ProfileGrid.test.tsx
+++ b/shared/ui/ProfileGrid.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { ProfileGrid } from './ProfileGrid';
+
+describe('ProfileGrid', () => {
+  it('uses responsive column classes', () => {
+    const html = renderToStaticMarkup(<ProfileGrid clips={[]} />);
+    expect(html).toContain('grid-cols-1');
+    expect(html).toContain('sm:grid-cols-2');
+    expect(html).toContain('lg:grid-cols-3');
+  });
+});

--- a/shared/ui/ProfileGrid.tsx
+++ b/shared/ui/ProfileGrid.tsx
@@ -12,7 +12,9 @@ export interface ProfileGridProps {
 
 /**
  * Responsive grid of clip thumbnails.
- * Two columns at >=600px and three columns at >=1024px.
+ * - Single column below 600px.
+ * - Two columns from 600px up to 1024px.
+ * - Three columns at widths of 1024px and above.
  */
 export const ProfileGrid: React.FC<ProfileGridProps> = ({ clips }) => (
   <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">

--- a/shared/ui/Timeline.test.tsx
+++ b/shared/ui/Timeline.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { Timeline } from './Timeline';
+
+describe('Timeline', () => {
+  it('centers content with blurred sidebars and includes bottom nav', () => {
+    const html = renderToStaticMarkup(<Timeline />);
+    expect(html).toContain('backdrop-blur');
+    expect(html).toContain('Home');
+  });
+});

--- a/shared/ui/Timeline.tsx
+++ b/shared/ui/Timeline.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { SwipeContainer } from './SwipeContainer';
 import { TimelineCard } from './TimelineCard';
 import { BalanceChip } from './BalanceChip';
+import { BottomNav } from './BottomNav';
 
 /**
  * Demo timeline that renders an infinite list of `TimelineCard`s.
@@ -45,15 +46,20 @@ export const Timeline: React.FC = () => {
   }, [ensureCard]);
 
   return (
-    <div className="flex h-screen flex-col">
+    <div className="relative flex h-screen flex-col">
       <header className="flex justify-end p-2">
         <BalanceChip />
       </header>
-      <div className="flex-1">
-        <SwipeContainer onIndexChange={handleIndexChange}>
-          {cards}
-        </SwipeContainer>
+      <div className="relative flex-1 flex justify-center">
+        <div className="w-full max-w-screen-md">
+          <SwipeContainer onIndexChange={handleIndexChange}>
+            {cards}
+          </SwipeContainer>
+        </div>
+        <div className="pointer-events-none fixed inset-y-0 left-0 hidden w-1/4 bg-gray-100/40 backdrop-blur lg:block" />
+        <div className="pointer-events-none fixed inset-y-0 right-0 hidden w-1/4 bg-gray-100/40 backdrop-blur lg:block" />
       </div>
+      <BottomNav />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- hide bottom nav on wide screens
- center timeline with blurred sidebars
- document and test responsive profile grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688de5e639348331a092fd9827f5840a