### PR TITLE
feat: post and wallet feedback

### DIFF
--- a/shared/ui/BalanceChip.test.tsx
+++ b/shared/ui/BalanceChip.test.tsx
@@ -6,13 +6,13 @@ import { useBalanceStore } from './balanceStore';
 
 describe('BalanceChip', () => {
   beforeEach(() => {
-    useBalanceStore.setState({ balance: 0 }, true);
+    useBalanceStore.setState({ balance: 0, txs: [] }, true);
   });
 
   it('renders balance and updates on change', () => {
     const initial = renderToStaticMarkup(<BalanceChip />);
     expect(initial).toContain('0 sats');
-    useBalanceStore.setState({ balance: 200 }, true);
+    useBalanceStore.setState({ balance: 200, txs: [] }, true);
     const updated = renderToStaticMarkup(<BalanceChip />);
     expect(updated).toContain('200 sats');
   });

--- a/shared/ui/Nav.test.tsx
+++ b/shared/ui/Nav.test.tsx
@@ -6,11 +6,11 @@ import { useBalanceStore } from './balanceStore';
 
 describe('Nav', () => {
   beforeEach(() => {
-    useBalanceStore.setState({ balance: 0 }, true);
+    useBalanceStore.setState({ balance: 0, txs: [] }, true);
   });
 
   it('renders logo and balance chip', () => {
-    useBalanceStore.setState({ balance: 123 }, true);
+    useBalanceStore.setState({ balance: 123, txs: [] }, true);
     const html = renderToStaticMarkup(<Nav />);
     expect(html).toContain('CashuCast');
     expect(html).toContain('123 sats');

--- a/shared/ui/PublishBtn.tsx
+++ b/shared/ui/PublishBtn.tsx
@@ -5,12 +5,33 @@ import React from 'react';
  */
 export interface PublishBtnProps {
   magnet?: string;
-  onPublish: () => void;
+  onPublish: () => void | Promise<void>;
 }
 
-export const PublishBtn: React.FC<PublishBtnProps> = ({ magnet, onPublish }) => (
-  <button disabled={!magnet} onClick={onPublish} className="px-4 py-2 bg-blue-500 text-white rounded disabled:bg-gray-400">
-    Publish
-  </button>
-);
+export const PublishBtn: React.FC<PublishBtnProps> = ({ magnet, onPublish }) => {
+  const [show, setShow] = React.useState(false);
+
+  const handleClick = async () => {
+    await onPublish();
+    setShow(true);
+    setTimeout(() => setShow(false), 3000);
+  };
+
+  return (
+    <>
+      <button
+        disabled={!magnet}
+        onClick={handleClick}
+        className="px-4 py-2 bg-blue-500 text-white rounded disabled:bg-gray-400"
+      >
+        Publish
+      </button>
+      {show && (
+        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-gray-800 text-white px-4 py-2 rounded">
+          Posted! Your followers will sync when online
+        </div>
+      )}
+    </>
+  );
+};
 

--- a/shared/ui/RefillBtn.tsx
+++ b/shared/ui/RefillBtn.tsx
@@ -1,15 +1,37 @@
 import React from 'react';
+import { useBalanceStore } from './balanceStore';
 
-/** Button to trigger wallet refill. Placeholder implementation. */
+/** Button to trigger wallet refill. Attempts to mint and falls back with a toast if unreachable. */
 export const RefillBtn: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = (
   props,
 ) => {
+  const mint = useBalanceStore((s) => s.mint);
+  const [toast, setToast] = React.useState(false);
+
+  const handleClick: React.MouseEventHandler<HTMLButtonElement> = async (e) => {
+    props.onClick?.(e);
+    try {
+      await mint(100);
+    } catch {
+      setToast(true);
+      setTimeout(() => setToast(false), 3000);
+    }
+  };
+
   return (
-    <button
-      {...props}
-      className={`px-3 py-1 bg-blue-500 text-white rounded ${props.className ?? ''}`}
-    >
-      Refill
-    </button>
+    <>
+      <button
+        {...props}
+        onClick={handleClick}
+        className={`px-3 py-1 bg-blue-500 text-white rounded ${props.className ?? ''}`}
+      >
+        Refill
+      </button>
+      {toast && (
+        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-gray-800 text-white px-4 py-2 rounded">
+          Mint unreachable. Transaction stored locally.
+        </div>
+      )}
+    </>
   );
 };

--- a/shared/ui/TxList.tsx
+++ b/shared/ui/TxList.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
+import { useBalanceStore } from './balanceStore';
 
-/** Placeholder transaction list. */
+/** Transaction list displaying wallet activity. */
 export const TxList: React.FC = () => {
+  const txs = useBalanceStore((s) => s.txs);
   return (
     <ul className="divide-y border rounded">
-      <li className="p-2">No transactions</li>
+      {txs.length === 0 && <li className="p-2">No transactions</li>}
+      {txs.map((tx) => (
+        <li key={tx.id} className="p-2">
+          {tx.type === 'mint' ? '+' : '-'}{tx.amount} sats - {tx.status}
+        </li>
+      ))}
     </ul>
   );
 };

--- a/shared/ui/ZapButton.test.tsx
+++ b/shared/ui/ZapButton.test.tsx
@@ -6,18 +6,18 @@ import { useBalanceStore } from './balanceStore';
 
 describe('ZapButton', () => {
   beforeEach(() => {
-    useBalanceStore.setState({ balance: 0 }, true);
+    useBalanceStore.setState({ balance: 0, txs: [] }, true);
   });
 
   it('disables amounts above balance', () => {
-    useBalanceStore.setState({ balance: 50 }, true);
+    useBalanceStore.setState({ balance: 50, txs: [] }, true);
     const html = renderToStaticMarkup(<ZapButton />);
     const disabledCount = (html.match(/disabled=""/g) || []).length;
     expect(disabledCount).toBe(2);
   });
 
   it('enables all amounts when balance high enough', () => {
-    useBalanceStore.setState({ balance: 2000 }, true);
+    useBalanceStore.setState({ balance: 2000, txs: [] }, true);
     const html = renderToStaticMarkup(<ZapButton />);
     expect(html).not.toContain('disabled=""');
   });

--- a/shared/ui/balanceStore.ts
+++ b/shared/ui/balanceStore.ts
@@ -8,21 +8,69 @@ const triggerConfetti = () => {
   }
 };
 
+const makeId = () => Math.random().toString(36).slice(2);
+
+interface Tx {
+  id: string;
+  type: 'mint' | 'zap';
+  amount: number;
+  status: 'success' | 'failed';
+}
+
 interface BalanceState {
   balance: number;
+  txs: Tx[];
   setBalance: (balance: number) => void;
+  mint: (amount: number) => Promise<void>;
   zap: (amount: number) => void;
 }
 
-export const useBalanceStore = create<BalanceState>((set) => ({
+export const useBalanceStore = create<BalanceState>((set, get) => ({
   balance: 0,
-  setBalance: (balance) => set({ balance }, true),
+  txs: [],
+  setBalance: (balance) =>
+    set(
+      (state) => {
+        if (balance > state.balance) {
+          triggerConfetti();
+        }
+        return { balance };
+      },
+      true,
+    ),
+  mint: async (amount) => {
+    try {
+      const res = await fetch('/mint', {
+        method: 'POST',
+        body: JSON.stringify({ amount }),
+      });
+      if (!res.ok) throw new Error('mint failed');
+      get().setBalance(get().balance + amount);
+      set(
+        (state) => ({
+          txs: [...state.txs, { id: makeId(), type: 'mint', amount, status: 'success' }],
+        }),
+        true,
+      );
+    } catch {
+      set(
+        (state) => ({
+          txs: [...state.txs, { id: makeId(), type: 'mint', amount, status: 'failed' }],
+        }),
+        true,
+      );
+      throw new Error('mint unreachable');
+    }
+  },
   zap: (amount) =>
     set(
       (state) => {
         if (state.balance >= amount) {
           triggerConfetti();
-          return { balance: state.balance - amount };
+          return {
+            balance: state.balance - amount,
+            txs: [...state.txs, { id: makeId(), type: 'zap', amount, status: 'success' }],
+          };
         }
         return state;
       },


### PR DESCRIPTION
## Summary
- show publish success snackbar with sync message
- track wallet transactions and trigger confetti on balance changes
- show toast and log failed mint attempts in wallet

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688de8a545dc8331b88c66a33343034c