### PR TITLE
feat: stream posts and play clips

### DIFF
--- a/packages/worker-ssb/index.ts
+++ b/packages/worker-ssb/index.ts
@@ -2,17 +2,20 @@ import { createRPCHandler } from '../../shared/rpc';
 
 // Temporary in-memory posts so the timeline has content during tests or
 // development. In a real implementation these would come from the SSB
-// network. Each post contains a simple author object and some text.
+// network. Each post contains a simple author object, some text and a
+// magnet link to a short clip.
 const mockPosts = [
   {
     id: '1',
     author: { name: 'Alice', pubkey: 'alicepk' },
     text: 'Hello from SSB',
+    magnet: 'magnet:?xt=urn:btih:alice',
   },
   {
     id: '2',
     author: { name: 'Bob', pubkey: 'bobpk' },
     text: 'Another post on the network',
+    magnet: 'magnet:?xt=urn:btih:bob',
   },
 ];
 

--- a/shared/ui/Timeline.tsx
+++ b/shared/ui/Timeline.tsx
@@ -8,7 +8,10 @@ import { createRPCClient } from '../rpc';
 interface Post {
   id: string;
   author: { name: string; pubkey: string };
-  text: string;
+  /** Magnet link for the post's clip */
+  magnet: string;
+  /** Optional text accompanying the clip */
+  text?: string;
 }
 
 /**
@@ -65,12 +68,9 @@ export const Timeline: React.FC = () => {
                 key={post.id}
                 author={post.author.name}
                 creatorId={post.author.pubkey}
+                magnet={post.magnet}
                 onZap={makeZapHandler(post)}
-              >
-                <div className="flex h-full items-center justify-center p-4">
-                  {post.text}
-                </div>
-              </TimelineCard>
+              />
             ))}
           </SwipeContainer>
         </div>

--- a/shared/ui/TimelineCard.tsx
+++ b/shared/ui/TimelineCard.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import { ZapButton } from './ZapButton';
 import { useSocialStore } from './socialStore';
+import { VideoPlayer } from './VideoPlayer';
 
 export interface TimelineCardProps {
   /** Author or channel name */
   author: string;
   /** Unique id for the author to sync stats */
   creatorId?: string;
-  /** Video or media content */
-  children?: React.ReactNode;
+  /** Magnet link for the clip to play */
+  magnet: string;
   /** Called with sat amount when user zaps */
   onZap?: (amount: number) => void;
 }
@@ -16,7 +17,7 @@ export interface TimelineCardProps {
 export const TimelineCard: React.FC<TimelineCardProps> = ({
   author,
   creatorId = author,
-  children,
+  magnet,
   onZap,
 }) => {
   const addZap = useSocialStore((s) => s.addZap);
@@ -27,7 +28,7 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({
   return (
     <article className="h-[90vh] w-full bg-white rounded-card shadow-sm flex flex-col">
       <div className="flex-1 flex items-center justify-center bg-gray-200">
-        {children ?? 'Video'}
+        <VideoPlayer magnet={magnet} />
       </div>
       <footer className="p-4 flex items-center justify-between">
         <span className="font-semibold">{author}</span>

--- a/shared/ui/VideoPlayer.test.tsx
+++ b/shared/ui/VideoPlayer.test.tsx
@@ -4,9 +4,10 @@ import { describe, it, expect } from 'vitest';
 import { VideoPlayer } from './VideoPlayer';
 
 describe('VideoPlayer', () => {
-  it('is muted by default and uses a blob URL', () => {
-    const html = renderToStaticMarkup(<VideoPlayer />);
-    expect(html).toContain('muted');
-    expect(html).toContain('src="blob:');
+  it('renders a skeleton loader while awaiting the stream URL', () => {
+    const html = renderToStaticMarkup(
+      <VideoPlayer magnet="magnet:?xt=urn:btih:test" />
+    );
+    expect(html).toContain('bg-gray-200');
   });
 });


### PR DESCRIPTION
## Summary
- stream magnet URLs in VideoPlayer via torrent worker RPC
- show each clip in TimelineCard and load magnet from mock SSB posts
- display skeleton until stream resolves while keeping muted autoplay

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688deb88e4a48331bb24a8aea824cb5d