### PR TITLE
feat: integrate wallet modal and zap rpc

### DIFF
--- a/shared/ui/Timeline.tsx
+++ b/shared/ui/Timeline.tsx
@@ -3,6 +3,7 @@ import { SwipeContainer } from './SwipeContainer';
 import { TimelineCard } from './TimelineCard';
 import { BalanceChip } from './BalanceChip';
 import { BottomNav } from './BottomNav';
+import { WalletModal } from './WalletModal';
 import { createRPCClient } from '../rpc';
 
 interface Post {
@@ -22,6 +23,7 @@ interface Post {
 export const Timeline: React.FC = () => {
   const [posts, setPosts] = useState<Post[]>([]);
   const cashuClient = useRef<ReturnType<typeof createRPCClient> | null>(null);
+  const [walletOpen, setWalletOpen] = useState(false);
 
   // load posts from the SSB worker
   useEffect(() => {
@@ -49,17 +51,19 @@ export const Timeline: React.FC = () => {
   }, []);
 
   const makeZapHandler = useCallback(
-    (post: Post) => (amount: number) => {
-      cashuClient.current?.('sendZap', post.author.pubkey, amount, post.id);
-    },
+    (post: Post) => (amount: number) =>
+      cashuClient.current?.('sendZap', post.author.pubkey, amount, post.id),
     []
   );
 
   return (
     <div className="relative flex h-screen flex-col">
       <header className="flex justify-end p-2">
-        <BalanceChip />
+        <button onClick={() => setWalletOpen(true)}>
+          <BalanceChip />
+        </button>
       </header>
+      <WalletModal open={walletOpen} onOpenChange={setWalletOpen} />
       <div className="relative flex-1 flex justify-center">
         <div className="w-full max-w-screen-md">
           <SwipeContainer>

--- a/shared/ui/TimelineCard.tsx
+++ b/shared/ui/TimelineCard.tsx
@@ -21,9 +21,17 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({
   onZap,
 }) => {
   const addZap = useSocialStore((s) => s.addZap);
-  const handleZap = (amt: number) => {
+  const [sending, setSending] = React.useState(false);
+  const handleZap = async (amt: number) => {
     addZap(creatorId, amt);
-    onZap?.(amt);
+    if (onZap) {
+      try {
+        setSending(true);
+        await onZap(amt);
+      } finally {
+        setSending(false);
+      }
+    }
   };
   return (
     <article className="h-[90vh] w-full bg-white rounded-card shadow-sm flex flex-col">
@@ -32,7 +40,7 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({
       </div>
       <footer className="p-4 flex items-center justify-between">
         <span className="font-semibold">{author}</span>
-        {onZap && <ZapButton onZap={handleZap} />}
+        {onZap && <ZapButton onZap={handleZap} disabled={sending} />}
       </footer>
     </article>
   );

--- a/shared/ui/WalletModal.tsx
+++ b/shared/ui/WalletModal.tsx
@@ -17,7 +17,16 @@ export const WalletModal: React.FC<WalletModalProps> = ({ open, onOpenChange }) 
   return (
     <BottomSheet open={open} onOpenChange={onOpenChange}>
       <div className="p-4 space-y-4">
-        <BalanceChip />
+        <div className="flex items-center justify-between">
+          <BalanceChip />
+          <button
+            onClick={() => onOpenChange(false)}
+            aria-label="Close wallet"
+            className="rounded bg-gray-200 px-2 py-1"
+          >
+            Close
+          </button>
+        </div>
         <MintPicker />
         <RefillBtn />
         <BackupSeedBtn />

--- a/shared/ui/ZapButton.test.tsx
+++ b/shared/ui/ZapButton.test.tsx
@@ -21,4 +21,11 @@ describe('ZapButton', () => {
     const html = renderToStaticMarkup(<ZapButton />);
     expect(html).not.toContain('disabled=""');
   });
+
+  it('disables all amounts when disabled prop set', () => {
+    useBalanceStore.setState({ balance: 2000, txs: [] }, true);
+    const html = renderToStaticMarkup(<ZapButton disabled />);
+    const disabledCount = (html.match(/disabled=""/g) || []).length;
+    expect(disabledCount).toBe(3);
+  });
 });

--- a/shared/ui/ZapButton.tsx
+++ b/shared/ui/ZapButton.tsx
@@ -3,11 +3,17 @@ import { useBalanceStore } from './balanceStore';
 
 export interface ZapButtonProps {
   onZap?: (amount: number) => void;
+  /** Disable all zap options */
+  disabled?: boolean;
 }
 
 const amounts = [21, 100, 1000];
 
-const ZapOption: React.FC<{ amount: number; onZap?: (amt: number) => void }> = ({ amount, onZap }) => {
+const ZapOption: React.FC<{
+  amount: number;
+  onZap?: (amt: number) => void;
+  disabled?: boolean;
+}> = ({ amount, onZap, disabled }) => {
   const balance =
     typeof window === 'undefined'
       ? useBalanceStore.getState().balance
@@ -51,7 +57,7 @@ const ZapOption: React.FC<{ amount: number; onZap?: (amt: number) => void }> = (
   return (
     <button
       className="px-2 py-1 bg-purple-600 text-white rounded disabled:opacity-50"
-      disabled={balance < amount}
+      disabled={disabled || balance < amount}
       onPointerDown={handlePointerDown}
       onPointerUp={handlePointerUp}
       onPointerLeave={handlePointerLeave}
@@ -61,10 +67,10 @@ const ZapOption: React.FC<{ amount: number; onZap?: (amt: number) => void }> = (
   );
 };
 
-export const ZapButton: React.FC<ZapButtonProps> = ({ onZap }) => (
+export const ZapButton: React.FC<ZapButtonProps> = ({ onZap, disabled }) => (
   <div className="flex gap-2">
     {amounts.map((amt) => (
-      <ZapOption key={amt} amount={amt} onZap={onZap} />
+      <ZapOption key={amt} amount={amt} onZap={onZap} disabled={disabled} />
     ))}
   </div>
 );


### PR DESCRIPTION
## Summary
- disable zap button while RPC pending
- call `sendZap` via shared zap button
- toggle wallet modal with balance and close

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688decde6aec83318efd1da8e92c5962