### PR TITLE
feat: extend post schema

### DIFF
--- a/packages/worker-ssb/index.ts
+++ b/packages/worker-ssb/index.ts
@@ -1,10 +1,11 @@
 import { createRPCHandler } from '../../shared/rpc';
+import type { Post } from '../../shared/types';
 
 // Temporary in-memory posts so the timeline has content during tests or
 // development. In a real implementation these would come from the SSB
 // network. Each post contains a simple author object, some text and a
 // magnet link to a short clip.
-const mockPosts = [
+const mockPosts: Post[] = [
   {
     id: '1',
     author: { name: 'Alice', pubkey: 'alicepk' },
@@ -20,9 +21,9 @@ const mockPosts = [
 ];
 
 createRPCHandler(self as any, {
-  publishPost: async (post) => {
+  publishPost: async (post: Post) => {
     // TODO: publish post to SSB
-    mockPosts.push(post as any);
+    mockPosts.push(post);
     return post;
   },
   queryFeed: async (_opts) => {

--- a/shared/rpc/index.ts
+++ b/shared/rpc/index.ts
@@ -1,14 +1,14 @@
 import { z } from 'zod';
 import { randomUUID } from 'node:crypto';
+import { PostSchema } from '../types';
 
 // Placeholder schemas for complex types
-const Post = z.any();
 const QueryOpts = z.any();
 const FileSchema = z.any();
 const Magnet = z.any();
 
 export const MethodDefinitions = {
-  publishPost: z.tuple([Post]),
+  publishPost: z.tuple([PostSchema]),
   queryFeed: z.tuple([QueryOpts]),
   seedFile: z.tuple([FileSchema]),
   stream: z.tuple([Magnet]),

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -1,0 +1,1 @@
+export * from './post';

--- a/shared/types/post.ts
+++ b/shared/types/post.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const PostSchema = z.object({
+  id: z.string(),
+  author: z.object({
+    name: z.string(),
+    pubkey: z.string(),
+  }),
+  /** Magnet link for the post's clip */
+  magnet: z.string(),
+  /** Optional text accompanying the clip */
+  text: z.string().optional(),
+  /** Whether the post is not safe for work */
+  nsfw: z.boolean().optional(),
+  /** Reports about the post from other users */
+  reports: z
+    .object({
+      fromPk: z.string(),
+      reason: z.string(),
+      ts: z.number(),
+    })
+    .array()
+    .optional(),
+});
+
+export type Post = z.infer<typeof PostSchema>;
+

--- a/shared/ui/Timeline.tsx
+++ b/shared/ui/Timeline.tsx
@@ -6,15 +6,7 @@ import { BottomNav } from './BottomNav';
 import { WalletModal } from './WalletModal';
 import { SkeletonLoader } from './SkeletonLoader';
 import { createRPCClient } from '../rpc';
-
-interface Post {
-  id: string;
-  author: { name: string; pubkey: string };
-  /** Magnet link for the post's clip */
-  magnet: string;
-  /** Optional text accompanying the clip */
-  text?: string;
-}
+import type { Post } from '../types';
 
 /**
  * Timeline that renders SSB posts inside `TimelineCard`s. Navigation between


### PR DESCRIPTION
## Summary
- extend post schema with optional `nsfw` flag and `reports` array
- share Post types between UI and workers
- validate `publishPost` RPC calls against Post schema

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688defdd54888331a203ffc8f5904b3c