### PR TITLE
feat: add settings store

### DIFF
--- a/shared/ui/index.ts
+++ b/shared/ui/index.ts
@@ -7,6 +7,7 @@ export * from './SkeletonLoader';
 export * from './BalanceChip';
 export * from './balanceStore';
 export * from './socialStore';
+export * from './settingsStore';
 export * from './BottomSheet';
 export * from './MintPicker';
 export * from './MintSelect';

--- a/shared/ui/settingsStore.ts
+++ b/shared/ui/settingsStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface SettingsState {
+  showNSFW: boolean;
+  setShowNSFW: (show: boolean) => void;
+}
+
+export const useSettingsStore = create<SettingsState>()(
+  persist(
+    (set) => ({
+      showNSFW: false,
+      setShowNSFW: (show) => set({ showNSFW: show }),
+    }),
+    { name: 'settings' },
+  ),
+);


### PR DESCRIPTION
## Summary
- add `useSettingsStore` with persisted `showNSFW` flag
- export settings store from shared UI module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688df24678708331929c7a80f0f47fe6