### PR TITLE
feat: show block and report warnings

### DIFF
--- a/shared/ui/Profile.test.tsx
+++ b/shared/ui/Profile.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { Profile } from './Profile';
+
+const baseProps = {
+  creatorId: 'id',
+  name: 'Alice',
+  clips: [],
+};
+
+describe('Profile', () => {
+  it('renders blocked banner when blocked', () => {
+    const html = renderToStaticMarkup(<Profile {...baseProps} blocked />);
+    expect(html).toContain('You have blocked this user');
+  });
+
+  it('does not render banner when not blocked', () => {
+    const html = renderToStaticMarkup(<Profile {...baseProps} />);
+    expect(html).not.toContain('You have blocked this user');
+  });
+});

--- a/shared/ui/Profile.tsx
+++ b/shared/ui/Profile.tsx
@@ -10,6 +10,8 @@ export interface ProfileProps {
   name: string;
   avatarUrl?: string;
   clips: ClipThumb[];
+  /** Whether the viewed user is blocked */
+  blocked?: boolean;
 }
 
 /**
@@ -20,12 +22,18 @@ export const Profile: React.FC<ProfileProps> = ({
   name,
   avatarUrl,
   clips,
+  blocked,
 }) => {
   const followers = useSocialStore(
     (s) => s.creators[creatorId]?.followers ?? 0,
   );
   return (
     <div className="flex flex-col gap-4 p-4">
+      {blocked && (
+        <div className="rounded bg-gray-200 p-2 text-center text-sm text-gray-700">
+          You have blocked this user.
+        </div>
+      )}
       <header className="flex items-center gap-4">
         <Avatar name={name} url={avatarUrl} />
         <div className="flex flex-col">

--- a/shared/ui/Timeline.tsx
+++ b/shared/ui/Timeline.tsx
@@ -7,6 +7,7 @@ import { WalletModal } from './WalletModal';
 import { SkeletonLoader } from './SkeletonLoader';
 import { createRPCClient } from '../rpc';
 import type { Post } from '../types';
+import { useSocialStore } from './socialStore';
 
 /**
  * Timeline that renders SSB posts inside `TimelineCard`s. Navigation between
@@ -18,6 +19,7 @@ export const Timeline: React.FC = () => {
   const cashuClient = useRef<ReturnType<typeof createRPCClient> | null>(null);
   const ssbClient = useRef<ReturnType<typeof createRPCClient> | null>(null);
   const [walletOpen, setWalletOpen] = useState(false);
+  const isModerator = useSocialStore((s) => s.isModerator);
 
   // load posts from the SSB worker
   useEffect(() => {
@@ -91,6 +93,8 @@ export const Timeline: React.FC = () => {
                   authorPubKey={post.author.pubkey}
                   onReport={handleReport}
                   onBlock={handleBlock}
+                  reports={post.reports?.length ?? 0}
+                  isModerator={isModerator}
                 />
               ))}
             </SwipeContainer>

--- a/shared/ui/TimelineCard.test.tsx
+++ b/shared/ui/TimelineCard.test.tsx
@@ -24,5 +24,19 @@ describe('TimelineCard', () => {
     );
     expect(html).not.toContain('NSFW – Tap to view');
   });
+
+  it('shows report badge for moderators', () => {
+    const html = renderToStaticMarkup(
+      <TimelineCard author="a" magnet={magnet} reports={2} isModerator />,
+    );
+    expect(html).toContain('⚑ 2');
+  });
+
+  it('hides report badge for non-moderators', () => {
+    const html = renderToStaticMarkup(
+      <TimelineCard author="a" magnet={magnet} reports={3} />,
+    );
+    expect(html).not.toContain('⚑ 3');
+  });
 });
 

--- a/shared/ui/TimelineCard.tsx
+++ b/shared/ui/TimelineCard.tsx
@@ -25,6 +25,10 @@ export interface TimelineCardProps {
   onReport?: (postId: string, reason: string) => void;
   /** Called when user blocks */
   onBlock?: (pubKey: string) => void;
+  /** Number of reports on the post */
+  reports?: number;
+  /** Whether the current viewer is a moderator */
+  isModerator?: boolean;
 }
 
 export const TimelineCard: React.FC<TimelineCardProps> = ({
@@ -37,6 +41,8 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({
   authorPubKey,
   onReport,
   onBlock,
+  reports = 0,
+  isModerator,
 }) => {
   const addZap = useSocialStore((s) => s.addZap);
   const [sending, setSending] = React.useState(false);
@@ -79,7 +85,14 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({
         )}
       </div>
       <footer className="p-4 flex items-center justify-between">
-        <span className="font-semibold">{author}</span>
+        <span className="font-semibold flex items-center gap-2">
+          {author}
+          {isModerator && reports > 0 && (
+            <span className="rounded-full bg-gray-200 px-2 py-1 text-xs">
+              ⚑ {reports}
+            </span>
+          )}
+        </span>
         <div className="flex items-center gap-2">
           {onZap && <ZapButton onZap={handleZap} disabled={sending} />}
           {postId &&

--- a/shared/ui/socialStore.ts
+++ b/shared/ui/socialStore.ts
@@ -8,12 +8,17 @@ interface CreatorStats {
 
 interface SocialState {
   creators: Record<string, CreatorStats>;
+  /** Whether the current viewer is a moderator */
+  isModerator: boolean;
+  setModerator: (isMod: boolean) => void;
   toggleFollow: (id: string) => void;
   addZap: (id: string, amount: number) => void;
 }
 
 export const useSocialStore = create<SocialState>((set) => ({
   creators: {},
+  isModerator: false,
+  setModerator: (isModerator) => set({ isModerator }),
   toggleFollow: (id) =>
     set((state) => {
       const current = state.creators[id] || {


### PR DESCRIPTION
## Summary
- warn when viewing a blocked profile
- show report counts to moderators on timeline cards
- add store flag to track moderator status

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688df97f4d248331a1d3a07f5500e68e