### PR TITLE
feat: redesign timeline card with overlays

### DIFF
--- a/shared/ui/Timeline.tsx
+++ b/shared/ui/Timeline.tsx
@@ -12,11 +12,10 @@ import { useSocialStore } from './socialStore';
 /**
  * Timeline that renders SSB posts inside `TimelineCard`s. Navigation between
  * cards is handled by `SwipeContainer`, which supports arrow keys and touch
- * gestures. Zaps trigger the Cashu RPC.
+ * gestures.
  */
 export const Timeline: React.FC = () => {
   const [posts, setPosts] = useState<Post[] | null>(null);
-  const cashuClient = useRef<ReturnType<typeof createRPCClient> | null>(null);
   const ssbClient = useRef<ReturnType<typeof createRPCClient> | null>(null);
   const [walletOpen, setWalletOpen] = useState(false);
   const isModerator = useSocialStore((s) => s.isModerator);
@@ -35,23 +34,6 @@ export const Timeline: React.FC = () => {
       .catch(() => setPosts([]));
     return () => worker.terminate();
   }, []);
-
-  // prepare Cashu RPC client for zaps
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const worker = new Worker(
-      new URL('../../packages/worker-cashu/index.ts', import.meta.url),
-      { type: 'module' }
-    );
-    cashuClient.current = createRPCClient(worker);
-    return () => worker.terminate();
-  }, []);
-
-  const makeZapHandler = useCallback(
-    (post: Post) => (amount: number) =>
-      cashuClient.current?.('sendZap', post.author.pubkey, amount, post.id),
-    []
-  );
 
   const handleReport = useCallback(
     (postId: string, reason: string) => {
@@ -84,11 +66,11 @@ export const Timeline: React.FC = () => {
               {posts.map((post) => (
                 <TimelineCard
                   key={post.id}
-                  author={post.author.name}
-                  creatorId={post.author.pubkey}
+                  name={post.author.name}
+                  avatarUrl=""
+                  text={post.text}
                   magnet={post.magnet}
                   nsfw={post.nsfw}
-                  onZap={makeZapHandler(post)}
                   postId={post.id}
                   authorPubKey={post.author.pubkey}
                   onReport={handleReport}

--- a/shared/ui/TimelineCard.test.tsx
+++ b/shared/ui/TimelineCard.test.tsx
@@ -13,28 +13,28 @@ describe('TimelineCard', () => {
 
   it('hides nsfw content when setting disabled', () => {
     const html = renderToStaticMarkup(
-      <TimelineCard author="a" magnet={magnet} nsfw />,
+      <TimelineCard name="a" avatarUrl="" magnet={magnet} nsfw />,
     );
     expect(html).toContain('NSFW – Tap to view');
   });
 
   it('shows normal content when not marked nsfw', () => {
     const html = renderToStaticMarkup(
-      <TimelineCard author="a" magnet={magnet} />,
+      <TimelineCard name="a" avatarUrl="" magnet={magnet} />,
     );
     expect(html).not.toContain('NSFW – Tap to view');
   });
 
   it('shows report badge for moderators', () => {
     const html = renderToStaticMarkup(
-      <TimelineCard author="a" magnet={magnet} reports={2} isModerator />,
+      <TimelineCard name="a" avatarUrl="" magnet={magnet} reports={2} isModerator />,
     );
     expect(html).toContain('⚑ 2');
   });
 
   it('hides report badge for non-moderators', () => {
     const html = renderToStaticMarkup(
-      <TimelineCard author="a" magnet={magnet} reports={3} />,
+      <TimelineCard name="a" avatarUrl="" magnet={magnet} reports={3} />,
     );
     expect(html).not.toContain('⚑ 3');
   });

--- a/shared/ui/__tests__/nsfw.test.tsx
+++ b/shared/ui/__tests__/nsfw.test.tsx
@@ -21,13 +21,17 @@ describe('NSFW toggle', () => {
   });
 
   it('hides NSFW content by default', () => {
-    const html = renderToStaticMarkup(<TimelineCard author="a" magnet={magnet} nsfw />);
+    const html = renderToStaticMarkup(
+      <TimelineCard name="a" avatarUrl="" magnet={magnet} nsfw />,
+    );
     expect(html).toContain('NSFW – Tap to view');
   });
 
   it('shows NSFW content when enabled', () => {
     useSettingsStore.getState().setShowNSFW(true);
-    const html = renderToStaticMarkup(<TimelineCard author="a" magnet={magnet} nsfw />);
+    const html = renderToStaticMarkup(
+      <TimelineCard name="a" avatarUrl="" magnet={magnet} nsfw />,
+    );
     expect(html).not.toContain('NSFW – Tap to view');
   });
 });


### PR DESCRIPTION
## Summary
- redesign `TimelineCard` with video-filling layout, overlay controls, and translucent caption block
- add `avatarUrl`, `name`, and `text` props while removing zap handling
- update `Timeline` to use the new card interface
- make avatar and username open a modal profile view with follow/unfollow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dfc49dfac8331962d0d1737552e12