### PR TITLE
feat: include avatar url in posts

### DIFF
--- a/packages/worker-ssb/__tests__/filters.test.ts
+++ b/packages/worker-ssb/__tests__/filters.test.ts
@@ -91,12 +91,12 @@ describe('worker-ssb feed filtering', () => {
     const { call, cleanup } = await setup();
     await call('publishPost', {
       id: 'a',
-      author: { name: 'A', pubkey: 'blockme' },
+      author: { name: 'A', pubkey: 'blockme', avatarUrl: 'https://example.com/a.png' },
       magnet: 'magnet:?xt=urn:btih:a',
     });
     await call('publishPost', {
       id: 'b',
-      author: { name: 'B', pubkey: 'keep' },
+      author: { name: 'B', pubkey: 'keep', avatarUrl: 'https://example.com/b.png' },
       magnet: 'magnet:?xt=urn:btih:b',
     });
     await call('blockUser', 'blockme');
@@ -111,13 +111,13 @@ describe('worker-ssb feed filtering', () => {
     self.SSB_REPORT_THRESHOLD = 2;
     await call('publishPost', {
       id: 'c',
-      author: { name: 'C', pubkey: 'c' },
+      author: { name: 'C', pubkey: 'c', avatarUrl: 'https://example.com/c.png' },
       magnet: 'magnet:?xt=urn:btih:c',
       reports: [{ fromPk: 'x', reason: 'spam', ts: 0 }],
     });
     await call('publishPost', {
       id: 'd',
-      author: { name: 'D', pubkey: 'd' },
+      author: { name: 'D', pubkey: 'd', avatarUrl: 'https://example.com/d.png' },
       magnet: 'magnet:?xt=urn:btih:d',
       reports: [
         { fromPk: 'x', reason: 'spam', ts: 0 },

--- a/packages/worker-ssb/index.ts
+++ b/packages/worker-ssb/index.ts
@@ -8,14 +8,14 @@ import type { Post } from '../../shared/types';
 const mockPosts: Post[] = [
   {
     id: '1',
-    author: { name: 'Alice', pubkey: 'alicepk' },
+    author: { name: 'Alice', pubkey: 'alicepk', avatarUrl: 'https://example.com/alice.png' },
     text: 'Hello from SSB',
     magnet: 'magnet:?xt=urn:btih:alice',
     nsfw: false,
   },
   {
     id: '2',
-    author: { name: 'Bob', pubkey: 'bobpk' },
+    author: { name: 'Bob', pubkey: 'bobpk', avatarUrl: 'https://example.com/bob.png' },
     text: 'Another post on the network',
     magnet: 'magnet:?xt=urn:btih:bob',
     nsfw: false,

--- a/shared/types/post.ts
+++ b/shared/types/post.ts
@@ -5,6 +5,7 @@ export const PostSchema = z.object({
   author: z.object({
     name: z.string(),
     pubkey: z.string(),
+    avatarUrl: z.string(),
   }),
   /** Magnet link for the post's clip */
   magnet: z.string(),

--- a/shared/ui/Timeline.tsx
+++ b/shared/ui/Timeline.tsx
@@ -67,7 +67,7 @@ export const Timeline: React.FC = () => {
                 <TimelineCard
                   key={post.id}
                   name={post.author.name}
-                  avatarUrl=""
+                  avatarUrl={post.author.avatarUrl}
                   text={post.text}
                   magnet={post.magnet}
                   nsfw={post.nsfw}


### PR DESCRIPTION
## Summary
- extend `Post` schema to include `author.avatarUrl`
- supply avatar URLs from the SSB worker
- render timeline cards with author avatars and text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688dfed33c44833190531c05da60e0a2