### PR TITLE
test: validate timeline card layout

### DIFF
--- a/shared/ui/Timeline.test.tsx
+++ b/shared/ui/Timeline.test.tsx
@@ -6,7 +6,8 @@ import { Timeline } from './Timeline';
 describe('Timeline', () => {
   it('centers content with blurred sidebars and includes bottom nav', () => {
     const html = renderToStaticMarkup(<Timeline />);
+    expect(html).toContain('max-w-screen-md');
     expect(html).toContain('backdrop-blur');
-    expect(html).toContain('Home');
+    expect(html).toContain('aria-label="Home"');
   });
 });

--- a/shared/ui/TimelineCard.test.tsx
+++ b/shared/ui/TimelineCard.test.tsx
@@ -38,5 +38,24 @@ describe('TimelineCard', () => {
     );
     expect(html).not.toContain('⚑ 3');
   });
+
+  it('renders avatar, username, menu button, and caption gradient', () => {
+    const html = renderToStaticMarkup(
+      <TimelineCard
+        name="Alice"
+        avatarUrl="/alice.png"
+        text="hello world"
+        magnet={magnet}
+        postId="1"
+        authorPubKey="pubkey"
+        onReport={() => {}}
+        onBlock={() => {}}
+      />,
+    );
+    expect(html).toContain('<img src="/alice.png"');
+    expect(html).toContain('<span class="font-semibold">Alice</span>');
+    expect(html).toContain('aria-label="Open post menu"');
+    expect(html).toContain('bg-black/60');
+  });
 });
 


### PR DESCRIPTION
## Summary
- verify TimelineCard renders avatar, user name, post menu, and caption overlay
- ensure Timeline layout test covers centered content and bottom nav

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e01546aa483318e9266f5493504fa