### PR TITLE
Add development and deployment scripts

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+echo "🏗  Building CashuCast for production…"
+
+# Clean old artifacts
+rm -rf apps/web/dist
+
+# Build workers first, then the React shell
+pnpm turbo run build --filter="worker-*"
+pnpm --filter apps/web build
+
+echo -e "\n✅  Build complete →  apps/web/dist"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+# ── Prerequisite checks ───────────────────────────────────────
+for cmd in pnpm docker; do
+  command -v "$cmd" >/dev/null || {
+    echo "❌  $cmd not found. Install it first."; exit 1; }
+done
+
+# ── Local side-car stack (room, tracker, regtest mint) ────────
+docker compose -f infra/docker/docker-compose.dev.yml up -d
+
+# ── Node dependencies ─────────────────────────────────────────
+pnpm install --frozen-lockfile
+
+# ── Run the web app with hot reload ───────────────────────────
+pnpm --filter apps/web dev

--- a/scripts/install_server.sh
+++ b/scripts/install_server.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# One-shot installer for Ubuntu 24.04 VPS
+# Usage (as root):  curl -sL https://raw.githubusercontent.com/<your-org>/cashucast/main/scripts/install_server.sh | bash
+set -e
+
+APT_PKGS="docker.io docker-compose caddy ufw fail2ban git"
+export DEBIAN_FRONTEND=noninteractive
+
+echo "🔑  Installing base packages…"
+apt-get update -y
+apt-get install -y $APT_PKGS
+
+systemctl enable --now docker
+
+echo "🔒  Configuring UFW…"
+ufw allow OpenSSH
+ufw allow 80,443/tcp
+ufw --force enable
+
+echo "📦  Cloning repo & starting stack…"
+mkdir -p /opt
+git clone https://github.com/<your-org>/cashucast /opt/cashucast
+cd /opt/cashucast/infra/docker
+docker compose -f docker-compose.prod.yml pull
+docker compose -f docker-compose.prod.yml up -d
+
+echo "🌐  Reloading Caddy (auto-TLS)…"
+cp /opt/cashucast/infra/docker/Caddyfile /etc/caddy/Caddyfile
+systemctl reload caddy
+
+echo -e "\n🚀  CashuCast room + tracker live under HTTPS."


### PR DESCRIPTION
## Summary
- add dev helper script to run local stack and web app
- add production build script
- add server install script for Ubuntu 24.04

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688e0275721883318b56e167a41334c1