### PR TITLE
feat: read worker configuration from settings store

### DIFF
--- a/packages/worker-ssb/index.ts
+++ b/packages/worker-ssb/index.ts
@@ -1,5 +1,8 @@
 import { createRPCHandler } from '../../shared/rpc';
 import type { Post } from '../../shared/types';
+import { useSettings } from '../../shared/store/settings';
+
+const { roomUrl } = useSettings.getState();
 
 // Temporary in-memory posts so the timeline has content during tests or
 // development. In a real implementation these would come from the SSB

--- a/packages/worker-torrent/index.ts
+++ b/packages/worker-torrent/index.ts
@@ -1,4 +1,7 @@
 import { createRPCHandler } from '../../shared/rpc';
+import { useSettings } from '../../shared/store/settings';
+
+const { trackerUrls: trackers } = useSettings.getState();
 
 createRPCHandler(self as any, {
   seedFile: async (file) => {

--- a/shared/config.ts
+++ b/shared/config.ts
@@ -14,6 +14,15 @@ const env = envSchema.parse(import.meta.env);
  * 2. Else fall back to VITE_* values.
  */
 export function getDefaultEndpoints() {
+  if (typeof window === 'undefined') {
+    return {
+      room: env.VITE_ROOM_URL || 'ws://localhost:4545',
+      trackerList: env.VITE_TRACKER_URLS
+        ? JSON.parse(env.VITE_TRACKER_URLS)
+        : ['ws://localhost:8000'],
+    };
+  }
+
   const host = window.location.hostname;
   // pattern: subdomain.domain.tld
   const [, domain, tld] = host.split('.').slice(-3);


### PR DESCRIPTION
## Summary
- load room and tracker URLs from shared settings store for workers
- default endpoints when `window` is undefined

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688e085efce88331a61434b1fd4dfcc5