### PR TITLE
feat: add storage settings slider

### DIFF
--- a/apps/web/src/routes/SettingsStorage.tsx
+++ b/apps/web/src/routes/SettingsStorage.tsx
@@ -1,0 +1,28 @@
+import { useSettings } from '../../shared/store/settings';
+import { setMaxCacheMB } from '../../../packages/worker-ssb/src/blobCache';
+
+export default function SettingsStorage() {
+  const { maxBlobMB, setMaxBlobMB } = useSettings();
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-xl font-semibold">Storage</h2>
+
+      <label className="block">
+        <span className="text-sm">Max offline video cache (MB): {maxBlobMB}</span>
+        <input
+          type="range"
+          min={128}
+          max={2048}
+          step={128}
+          value={maxBlobMB}
+          onChange={(e) => {
+            const mb = Number(e.target.value);
+            setMaxBlobMB(mb);
+            setMaxCacheMB(mb);      // tell blobCache helper
+          }}
+          className="w-full"
+        />
+      </label>
+    </div>
+  );
+}

--- a/shared/store/settings.ts
+++ b/shared/store/settings.ts
@@ -4,9 +4,11 @@ import { getDefaultEndpoints } from '../config';
 
 interface SettingsState {
   showNSFW: boolean;
+  maxBlobMB: number;
   roomUrl: string;
   trackerUrls: string[];
   setShowNSFW: (v: boolean) => void;
+  setMaxBlobMB: (mb: number) => void;
   setRoomUrl: (u: string) => void;
   addTracker: (u: string) => void;
   removeTracker: (u: string) => void;
@@ -18,14 +20,19 @@ export const useSettings = create<SettingsState>()(
       const { room, trackerList } = getDefaultEndpoints();
       return {
         showNSFW: false,
+        maxBlobMB: 512,
         roomUrl: room,
         trackerUrls: trackerList,
         setShowNSFW: (v) => set({ showNSFW: v }),
         setRoomUrl: (u) => set({ roomUrl: u }),
         addTracker: (u) =>
           set({ trackerUrls: Array.from(new Set([...get().trackerUrls, u])) }),
-        removeTracker: (u) =>
-          set({ trackerUrls: get().trackerUrls.filter((x) => x !== u) }),
+        removeTracker(u: string) {
+          set({ trackerUrls: get().trackerUrls.filter((x) => x !== u) });
+        },
+        setMaxBlobMB(mb: number) {
+          set({ maxBlobMB: mb });
+        }
       };
     },
     { name: 'cashucast-settings' },


### PR DESCRIPTION
## Summary
- add max offline cache size to settings store
- new storage settings screen with slider

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688e0c7f421083318ba66dcd63008f50