### PR TITLE
feat: add thumbnail picker for compose

### DIFF
--- a/apps/web/src/components/ThumbnailPicker.tsx
+++ b/apps/web/src/components/ThumbnailPicker.tsx
@@ -1,0 +1,132 @@
+import { useState, useEffect, useCallback } from 'react';
+import Cropper from 'react-easy-crop';
+import { createFFmpeg, fetchFile } from '@ffmpeg/ffmpeg';
+import Dropzone from 'react-dropzone';
+import { getSSB } from '../../../../packages/worker-ssb/src/instance';
+import { touch } from '../../../../packages/worker-ssb/src/blobCache';
+
+interface ThumbnailPickerProps {
+  file: Blob;
+  onSelect: (hash: string) => void;
+}
+
+export default function ThumbnailPicker({ file, onSelect }: ThumbnailPickerProps) {
+  const [thumbs, setThumbs] = useState<{ src: string; blob: Blob }[]>([]);
+  const [cropSrc, setCropSrc] = useState<string | null>(null);
+  const [crop, setCrop] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<any>(null);
+
+  useEffect(() => {
+    const run = async () => {
+      const ffmpeg = createFFmpeg({ log: false });
+      await ffmpeg.load();
+      ffmpeg.FS('writeFile', 'input.mp4', await fetchFile(file));
+      const times = ['00:00:01', '00:00:02', '00:00:03'];
+      const imgs: { src: string; blob: Blob }[] = [];
+      for (let i = 0; i < times.length; i++) {
+        await ffmpeg.run('-ss', times[i], '-i', 'input.mp4', '-frames:v', '1', `out${i}.jpg`);
+        const data = ffmpeg.FS('readFile', `out${i}.jpg`);
+        const blob = new Blob([data.buffer], { type: 'image/jpeg' });
+        imgs.push({ src: URL.createObjectURL(blob), blob });
+      }
+      setThumbs(imgs);
+    };
+    run();
+  }, [file]);
+
+  const saveBlob = async (blob: Blob) => {
+    const ssb = getSSB();
+    const writer = ssb.blobs.add();
+    const data = new Uint8Array(await blob.arrayBuffer());
+    writer.write(data);
+    writer.end((_: any, hash: string) => {
+      touch(hash, data.byteLength);
+      onSelect(hash);
+    });
+  };
+
+  const handleSelect = (blob: Blob) => {
+    saveBlob(blob);
+  };
+
+  const onCropComplete = useCallback((_croppedArea, croppedAreaPixels) => {
+    setCroppedAreaPixels(croppedAreaPixels);
+  }, []);
+
+  const createCroppedImage = useCallback(async () => {
+    if (!cropSrc || !croppedAreaPixels) return;
+    const image = document.createElement('img');
+    image.src = cropSrc;
+    await new Promise((res) => (image.onload = res));
+    const canvas = document.createElement('canvas');
+    canvas.width = croppedAreaPixels.width;
+    canvas.height = croppedAreaPixels.height;
+    const ctx = canvas.getContext('2d');
+    ctx?.drawImage(
+      image,
+      croppedAreaPixels.x,
+      croppedAreaPixels.y,
+      croppedAreaPixels.width,
+      croppedAreaPixels.height,
+      0,
+      0,
+      croppedAreaPixels.width,
+      croppedAreaPixels.height
+    );
+    canvas.toBlob((blob) => blob && handleSelect(blob), 'image/jpeg');
+  }, [cropSrc, croppedAreaPixels]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2">
+        {thumbs.map((t, i) => (
+          <img
+            key={i}
+            src={t.src}
+            className="w-24 h-24 object-cover cursor-pointer"
+            onClick={() => handleSelect(t.blob)}
+          />
+        ))}
+        <Dropzone
+          onDrop={(files) => {
+            const f = files[0];
+            if (f) setCropSrc(URL.createObjectURL(f));
+          }}
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div
+              {...getRootProps()}
+              className="w-24 h-24 flex items-center justify-center border-2 border-dashed cursor-pointer"
+            >
+              <input {...getInputProps()} />
+              <span>Upload</span>
+            </div>
+          )}
+        </Dropzone>
+      </div>
+      {cropSrc && (
+        <div>
+          <div className="relative w-full h-64">
+            <Cropper
+              image={cropSrc}
+              crop={crop}
+              zoom={zoom}
+              aspect={16 / 9}
+              onCropChange={setCrop}
+              onZoomChange={setZoom}
+              onCropComplete={onCropComplete}
+            />
+          </div>
+          <button
+            className="mt-2 rounded bg-blue-500 px-4 py-2 text-white"
+            onClick={createCroppedImage}
+          >
+            Use
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/apps/web/src/routes/Compose.tsx
+++ b/apps/web/src/routes/Compose.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { UploadDropzone, TranscodeModal, CaptionTextarea, PublishBtn } from '../../shared/ui';
+import ThumbnailPicker from '../components/ThumbnailPicker';
+
+export default function Compose() {
+  const [file, setFile] = useState<File | null>(null);
+  const [magnet, setMagnet] = useState<string | null>(null);
+  const [thumbHash, setThumbHash] = useState<string | null>(null);
+  const [caption, setCaption] = useState('');
+
+  const handleFile = (f: File) => {
+    setFile(f);
+    setMagnet(null);
+    setThumbHash(null);
+  };
+
+  const onPublish = async () => {
+    // placeholder publish logic
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      {!file && <UploadDropzone onFile={handleFile} />}
+      {file && (
+        <>
+          <TranscodeModal open={!magnet} file={file} onComplete={setMagnet} />
+          {magnet && <ThumbnailPicker file={file} onSelect={setThumbHash} />}
+          <CaptionTextarea value={caption} onChange={setCaption} />
+          <PublishBtn
+            magnet={magnet && thumbHash ? magnet : undefined}
+            onPublish={onPublish}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+

--- a/package.json
+++ b/package.json
@@ -11,12 +11,15 @@
   "license": "GPL-3.0-or-later",
   "type": "module",
   "dependencies": {
+    "@ffmpeg/ffmpeg": "^0.12.0",
     "@radix-ui/react-dialog": "^1.1.14",
     "canvas-confetti": "^1.9.3",
     "lucide-react": "^0.536.0",
     "quick-lru": "^7.0.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-dropzone": "^14.3.8",
+    "react-easy-crop": "^5.5.0",
     "ssb-blobs": "^2.0.1",
     "zod": "^4.0.14",
     "zustand": "^5.0.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@ffmpeg/ffmpeg':
+        specifier: ^0.12.0
+        version: 0.12.15
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.14(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -26,6 +29,12 @@ importers:
       react-dom:
         specifier: ^19.1.1
         version: 19.1.1(react@19.1.1)
+      react-dropzone:
+        specifier: ^14.3.8
+        version: 14.3.8(react@19.1.1)
+      react-easy-crop:
+        specifier: ^5.5.0
+        version: 5.5.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       ssb-blobs:
         specifier: ^2.0.1
         version: 2.0.1
@@ -243,6 +252,14 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@ffmpeg/ffmpeg@0.12.15':
+    resolution: {integrity: sha512-1C8Obr4GsN3xw+/1Ww6PFM84wSQAGsdoTuTWPOj2OizsRDLT4CXTaVjPhkw6ARyDus1B9X/L2LiXHqYYsGnRFw==}
+    engines: {node: '>=18.x'}
+
+  '@ffmpeg/types@0.12.4':
+    resolution: {integrity: sha512-k9vJQNBGTxE5AhYDtOYR5rO5fKsspbg51gbcwtbkw2lCdoIILzklulcjJfIDwrtn7XhDeF2M+THwJ2FGrLeV6A==}
+    engines: {node: '>=16.x'}
 
   '@jridgewell/sourcemap-codec@1.5.4':
     resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
@@ -589,6 +606,10 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  attr-accept@2.2.5:
+    resolution: {integrity: sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==}
+    engines: {node: '>=4'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -724,6 +745,10 @@ packages:
       picomatch:
         optional: true
 
+  file-selector@2.1.2:
+    resolution: {integrity: sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==}
+    engines: {node: '>= 12'}
+
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -780,6 +805,9 @@ packages:
 
   is-valid-domain@0.0.20:
     resolution: {integrity: sha512-Yd9oD7sgCycVvH8CHy5U4fLXibPwxVw2+diudYbT8ZfAiQDtW1H9WvPRR4+rtN9qOll+r+KAfO4SjO28OPpitA==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
@@ -851,6 +879,10 @@ packages:
   looper@4.0.0:
     resolution: {integrity: sha512-NjGRcX4vCwyfbujv03omakGfAYh6St5kVsZFKfU23MFO1Z9/mZT8ypTZMEnvVC7nJeYtbqkRPFV4GoJBPdJgYw==}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   loupe@3.2.0:
     resolution: {integrity: sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==}
 
@@ -904,8 +936,15 @@ packages:
     resolution: {integrity: sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ==}
     hasBin: true
 
+  normalize-wheel@1.0.1:
+    resolution: {integrity: sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==}
+
   nwsapi@2.2.21:
     resolution: {integrity: sha512-o6nIY3qwiSXl7/LuOU0Dmuctd34Yay0yeuZRLFmDPrrdHpXKFndPj3hM+YEPVHYC5fx2otBx4Ilc/gyYSAUaIA==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   obz@1.1.1:
     resolution: {integrity: sha512-eUiAX663dASOUIEWuRzUycf2ERZJFLbdjfzYRtju9z2eBfDPywcWjfyHV5JNbVoBjuHGVodyfeyy8Qu09+JCXw==}
@@ -937,6 +976,9 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
   prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
@@ -1015,6 +1057,21 @@ packages:
     resolution: {integrity: sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==}
     peerDependencies:
       react: ^19.1.1
+
+  react-dropzone@14.3.8:
+    resolution: {integrity: sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==}
+    engines: {node: '>= 10.13'}
+    peerDependencies:
+      react: '>= 16.8 || 18.0.0'
+
+  react-easy-crop@5.5.0:
+    resolution: {integrity: sha512-OZzU+yXMhe69vLkDex+5QxcfT94FdcgVCyW2dBUw35ZoC3Is42TUxUy04w8nH1mfMKaizVdC3rh/wUfNW1mK4w==}
+    peerDependencies:
+      react: '>=16.4.0'
+      react-dom: '>=16.4.0'
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -1439,6 +1496,12 @@ snapshots:
   '@esbuild/win32-x64@0.25.8':
     optional: true
 
+  '@ffmpeg/ffmpeg@0.12.15':
+    dependencies:
+      '@ffmpeg/types': 0.12.4
+
+  '@ffmpeg/types@0.12.4': {}
+
   '@jridgewell/sourcemap-codec@1.5.4': {}
 
   '@radix-ui/primitive@1.1.2': {}
@@ -1730,6 +1793,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  attr-accept@2.2.5: {}
+
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
@@ -1874,6 +1939,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  file-selector@2.1.2:
+    dependencies:
+      tslib: 2.8.1
+
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
@@ -1932,6 +2001,8 @@ snapshots:
   is-valid-domain@0.0.20:
     dependencies:
       punycode: 1.4.1
+
+  js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
 
@@ -2024,6 +2095,10 @@ snapshots:
 
   looper@4.0.0: {}
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   loupe@3.2.0: {}
 
   lru-cache@10.4.3: {}
@@ -2083,7 +2158,11 @@ snapshots:
 
   node-gyp-build@4.1.1: {}
 
+  normalize-wheel@1.0.1: {}
+
   nwsapi@2.2.21: {}
+
+  object-assign@4.1.1: {}
 
   obz@1.1.1: {}
 
@@ -2110,6 +2189,12 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
 
   prr@1.0.1: {}
 
@@ -2193,6 +2278,22 @@ snapshots:
     dependencies:
       react: 19.1.1
       scheduler: 0.26.0
+
+  react-dropzone@14.3.8(react@19.1.1):
+    dependencies:
+      attr-accept: 2.2.5
+      file-selector: 2.1.2
+      prop-types: 15.8.1
+      react: 19.1.1
+
+  react-easy-crop@5.5.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      normalize-wheel: 1.0.1
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      tslib: 2.8.1
+
+  react-is@16.13.1: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.1.9)(react@19.1.1):
     dependencies:


### PR DESCRIPTION
## Summary
- add ffmpeg, cropper, and dropzone deps
- create ThumbnailPicker to capture frames or crop upload and store via SSB
- integrate thumbnail selection into compose flow and gate publish on thumbnail choice

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688e0e677dc88331aef23135a8fa1a8d