### PR TITLE
feat: add tag input

### DIFF
--- a/apps/web/src/components/TagInput.tsx
+++ b/apps/web/src/components/TagInput.tsx
@@ -1,0 +1,25 @@
+/* wraps Tagify; lower-cases, strips leading #, max 10 tags */
+import Tags from '@yaireo/tagify/dist/react.tagify';
+
+export default function TagInput({
+  value,
+  setValue,
+}: {
+  value: string[];
+  setValue: (v: string[]) => void;
+}) {
+  return (
+    <Tags
+      value={value.join(',')}
+      settings={{
+        maxTags: 10,
+        transformTag(tagData) {
+          tagData.value = tagData.value.toLowerCase().replace(/^#/, '');
+        },
+      }}
+      onChange={(e) =>
+        setValue(e.detail.tagify.value.map((t: any) => t.value))
+      }
+    />
+  );
+}

--- a/apps/web/src/routes/Compose.tsx
+++ b/apps/web/src/routes/Compose.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react';
 import { UploadDropzone, TranscodeModal, CaptionTextarea, PublishBtn } from '../../shared/ui';
 import ThumbnailPicker from '../components/ThumbnailPicker';
+import TagInput from '../components/TagInput';
 
 export default function Compose() {
   const [file, setFile] = useState<File | null>(null);
   const [magnet, setMagnet] = useState<string | null>(null);
   const [thumbHash, setThumbHash] = useState<string | null>(null);
   const [caption, setCaption] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
 
   const handleFile = (f: File) => {
     setFile(f);
@@ -26,8 +28,9 @@ export default function Compose() {
           <TranscodeModal open={!magnet} file={file} onComplete={setMagnet} />
           {magnet && <ThumbnailPicker file={file} onSelect={setThumbHash} />}
           <CaptionTextarea value={caption} onChange={setCaption} />
+          <TagInput value={tags} setValue={setTags} />
           <PublishBtn
-            magnet={magnet && thumbHash ? magnet : undefined}
+            magnet={magnet && thumbHash && tags.length <= 10 ? magnet : undefined}
             onPublish={onPublish}
           />
         </>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@ffmpeg/ffmpeg": "^0.12.0",
     "@radix-ui/react-dialog": "^1.1.14",
+    "@yaireo/tagify": "^4.35.3",
     "canvas-confetti": "^1.9.3",
     "lucide-react": "^0.536.0",
     "quick-lru": "^7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.14(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@yaireo/tagify':
+        specifier: ^4.35.3
+        version: 4.35.3(prop-types@15.8.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       canvas-confetti:
         specifier: ^1.9.3
         version: 1.9.3
@@ -583,6 +586,14 @@ packages:
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@yaireo/tagify@4.35.3':
+    resolution: {integrity: sha512-YXqNIHoKwZXRxeMSu1E9/CaE/e4rC81RUyg2IaPYh6ZmcAl+7dVi/QoNV1pGu7MLXIqQYpXyXxzDoweIOF7GIw==}
+    engines: {node: '>=16.15.0', npm: '>=9.0.0'}
+    peerDependencies:
+      prop-types: '>15.5.7'
+      react: '*'
+      react-dom: '*'
 
   abstract-leveldown@6.2.3:
     resolution: {integrity: sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==}
@@ -1768,6 +1779,12 @@ snapshots:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.0
       tinyrainbow: 2.0.0
+
+  '@yaireo/tagify@4.35.3(prop-types@15.8.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      prop-types: 15.8.1
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
 
   abstract-leveldown@6.2.3:
     dependencies:


### PR DESCRIPTION
## Summary
- add TagInput component wrapping Tagify
- wire TagInput into compose screen
- disallow publish when over 10 tags

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688e0fd663808331ae919d9bbf66b58f