### PR TITLE
feat: add wallet initialization handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@yaireo/tagify": "^4.35.3",
     "canvas-confetti": "^1.9.3",
+    "bip39": "^3.1.0",
     "lucide-react": "^0.536.0",
     "quick-lru": "^7.0.1",
     "react": "^19.1.1",

--- a/packages/worker-cashu/index.ts
+++ b/packages/worker-cashu/index.ts
@@ -1,4 +1,5 @@
 import { createRPCHandler } from '../../shared/rpc';
+import { generateMnemonic } from 'bip39';
 
 createRPCHandler(self as any, {
   mint: async (sats) => {
@@ -8,5 +9,9 @@ createRPCHandler(self as any, {
   sendZap: async (receiverPk, sats, refId) => {
     // TODO: send zap
     return { receiverPk, sats, refId };
+  },
+  initWallet: async (mnemonic?: string) => {
+    const phrase = mnemonic ?? generateMnemonic();
+    return phrase;
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@yaireo/tagify':
         specifier: ^4.35.3
         version: 4.35.3(prop-types@15.8.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      bip39:
+        specifier: ^3.1.0
+        version: 3.1.0
       canvas-confetti:
         specifier: ^1.9.3
         version: 1.9.3
@@ -266,6 +269,10 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.4':
     resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
@@ -626,6 +633,9 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bip39@3.1.0:
+    resolution: {integrity: sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==}
 
   blake2s@1.1.0:
     resolution: {integrity: sha512-lvCxvg+up7AmujO8vijTi4GsbIOuusWa+b/nN5+VAanFjzbauq0er5VzgjTC6pevhEO8SYTzY784zS2KQauO0A==}
@@ -1515,6 +1525,8 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.4': {}
 
+  '@noble/hashes@1.8.0': {}
+
   '@radix-ui/primitive@1.1.2': {}
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.9)(react@19.1.1)':
@@ -1815,6 +1827,10 @@ snapshots:
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
+
+  bip39@3.1.0:
+    dependencies:
+      '@noble/hashes': 1.8.0
 
   blake2s@1.1.0: {}
 


### PR DESCRIPTION
## Summary
- add Cashu worker initWallet handler and generate mnemonic when needed
- install bip39 for mnemonic generation

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688e181806988331b840f1550d87013f