### PR TITLE
feat(web): gate routes behind onboarding

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Onboarding from './routes/Onboarding';
+import Compose from './routes/Compose';
+import SettingsNetwork from './routes/SettingsNetwork';
+import SettingsStorage from './routes/SettingsStorage';
+import { useProfile } from '../../shared/store/profile';
+
+const ROUTES: Record<string, React.FC> = {
+  '/compose': Compose,
+  '/settings/network': SettingsNetwork,
+  '/settings/storage': SettingsStorage,
+  '/': Compose,
+};
+
+export default function App() {
+  const profile = useProfile((s) => s.profile);
+  const [path, setPath] = React.useState(() => window.location.pathname);
+
+  React.useEffect(() => {
+    const onPopState = () => setPath(window.location.pathname);
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, []);
+
+  if (!profile?.ssbPk) {
+    return <Onboarding />;
+  }
+
+  const RouteComponent = ROUTES[path];
+  return RouteComponent ? <RouteComponent /> : <div>Not Found</div>;
+}


### PR DESCRIPTION
## Summary
- add App component that checks for profile and displays onboarding dialog when missing
- route to compose or settings screens when profile exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e825d4d28833196bcd79d38b55ae5