### PR TITLE
feat(web): add profile settings page

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,12 +3,14 @@ import Onboarding from './routes/Onboarding';
 import Compose from './routes/Compose';
 import SettingsNetwork from './routes/SettingsNetwork';
 import SettingsStorage from './routes/SettingsStorage';
+import SettingsProfile from './routes/SettingsProfile';
 import { useProfile } from '../../shared/store/profile';
 
 const ROUTES: Record<string, React.FC> = {
   '/compose': Compose,
   '/settings/network': SettingsNetwork,
   '/settings/storage': SettingsStorage,
+  '/settings/profile': SettingsProfile,
   '/': Compose,
 };
 

--- a/apps/web/src/routes/SettingsProfile.tsx
+++ b/apps/web/src/routes/SettingsProfile.tsx
@@ -1,0 +1,44 @@
+import { useProfile } from '../../shared/store/profile';
+
+export default function SettingsProfile() {
+  const exportProfile = useProfile((s) => s.exportProfile);
+
+  const onExport = () => {
+    const blob = exportProfile();
+    const url = URL.createObjectURL(blob);
+    const date = new Date().toISOString().split('T')[0];
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `cashucast-backup-${date}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  const onReset = async () => {
+    await useProfile.persist.clearStorage();
+    window.location.reload();
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-xl font-semibold">Profile</h2>
+      <div className="space-x-2">
+        <button
+          onClick={onExport}
+          className="rounded bg-primary px-3 py-2 text-white"
+        >
+          Export Backup
+        </button>
+        <button
+          onClick={onReset}
+          className="rounded bg-red-600 px-3 py-2 text-white"
+        >
+          Reset App
+        </button>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add profile settings route with backup export and reset actions
- register profile settings route in app router

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e83422f948331af0ce523ce433662