### PR TITLE
Integrate browser SSB stack and log replication tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "@ffmpeg/ffmpeg": "^0.12.0",
     "@radix-ui/react-dialog": "^1.1.14",
     "@yaireo/tagify": "^4.35.3",
-    "canvas-confetti": "^1.9.3",
     "bip39": "^3.1.0",
+    "canvas-confetti": "^1.9.3",
     "lucide-react": "^0.536.0",
     "quick-lru": "^7.0.1",
     "react": "^19.1.1",
@@ -23,6 +23,7 @@
     "react-dropzone": "^14.3.8",
     "react-easy-crop": "^5.5.0",
     "ssb-blobs": "^2.0.1",
+    "ssb-browser-core": "14.0.0",
     "zod": "^4.0.14",
     "zustand": "^5.0.7"
   },

--- a/packages/worker-ssb/__tests__/replication.test.ts
+++ b/packages/worker-ssb/__tests__/replication.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createRPCClient } from '../../../shared/rpc';
+
+function createPortPair() {
+  const listeners1: ((ev: MessageEvent) => void)[] = [];
+  const listeners2: ((ev: MessageEvent) => void)[] = [];
+  const port1 = {
+    postMessage(data: any) {
+      listeners2.forEach((l) => l({ data } as MessageEvent));
+    },
+    addEventListener(_type: 'message', listener: (ev: MessageEvent) => void) {
+      listeners1.push(listener);
+    },
+    removeEventListener(_type: 'message', listener: (ev: MessageEvent) => void) {
+      const idx = listeners1.indexOf(listener);
+      if (idx >= 0) listeners1.splice(idx, 1);
+    },
+    start() {},
+  } as any;
+  const port2 = {
+    postMessage(data: any) {
+      listeners1.forEach((l) => l({ data } as MessageEvent));
+    },
+    addEventListener(_type: 'message', listener: (ev: MessageEvent) => void) {
+      listeners2.push(listener);
+    },
+    removeEventListener(_type: 'message', listener: (ev: MessageEvent) => void) {
+      const idx = listeners2.indexOf(listener);
+      if (idx >= 0) listeners2.splice(idx, 1);
+    },
+    start() {},
+  } as any;
+  return { port1, port2 };
+}
+
+async function setup(resetLog: boolean) {
+  vi.resetModules();
+  if (resetLog) (globalThis as any).__cashuSSBLog = [];
+  const { port1, port2 } = createPortPair();
+  (globalThis as any).self = port1;
+  await import('../index');
+  const call = createRPCClient(port2);
+  const cleanup = () => {
+    delete (globalThis as any).self;
+  };
+  return { call, cleanup };
+}
+
+describe('worker-ssb replication', () => {
+  it('replicates posts across instances', async () => {
+    const { call, cleanup } = await setup(true);
+    await call('publishPost', {
+      id: 'r1',
+      author: { name: 'R', pubkey: 'r', avatarUrl: 'https://example.com/r.png' },
+      magnet: 'magnet:?xt=urn:btih:r1',
+    });
+    cleanup();
+
+    const { call: call2, cleanup: cleanup2 } = await setup(false);
+    const feed: any[] = await call2('queryFeed', {});
+    expect(feed.some((p) => p.id === 'r1')).toBe(true);
+    cleanup2();
+  });
+});
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       ssb-blobs:
         specifier: ^2.0.1
         version: 2.0.1
+      ssb-browser-core:
+        specifier: 14.0.0
+        version: 14.0.0
       zod:
         specifier: ^4.0.14
         version: 4.0.14
@@ -71,6 +74,10 @@ importers:
         version: 3.2.4(@types/node@24.1.0)(jsdom@26.1.0)
 
 packages:
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -269,6 +276,15 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.4':
     resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
+
+  '@minireq/browser@2.0.0':
+    resolution: {integrity: sha512-0A6KOXLL+EQlFaLjNKvH2bRxy8fKPH/DNBy7IXq36LdSPubbzmJ8qoPTxTCfFsTVSFhozEhn48u8QjoyEQq2BQ==}
+
+  '@minireq/common@2.0.0':
+    resolution: {integrity: sha512-dVza/V5g0uURv2rnJ2vNchb8WlrOVlkLHscfO74poiFB4nPqnYz+8bLVY2uwH9W/1SAG73kEZPOsGibBnn7rBg==}
+
+  '@minireq/node@2.0.0':
+    resolution: {integrity: sha512-qaXdz7sQb45Q8r2MGUadP1Wj8cjQ+srG0FhXGiv+5HoD1Mdl3hEqRy1OFjgiAY8KCgt4tIV8W5heYZ6H94A42w==}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -545,6 +561,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sammacbeth/random-access-idb-mutable-file@0.1.1':
+    resolution: {integrity: sha512-jHnpuu2qtFgwCmhgrpCCk3/hU3XqXTqhidh4XmcTijkVsGwh1c2T0+r2hkHs1PRfsxeimx8qDAotphpRoYB2eg==}
+
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
@@ -616,17 +635,54 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  aligned-block-file@1.2.2:
+    resolution: {integrity: sha512-2Sy0hWhifVb8ycNFJgicL8fDPL2Ct1r62XOVxXnykn36z22MPZwnQlCmB2viQlY/lwfuO67GaQjUZ0rJgdVP7Q==}
+
+  append-batch@0.0.2:
+    resolution: {integrity: sha512-v1lD0bKqM4MTtGzapIx6qCGcwbVJyKaTmbzIzA6kpnVwTY1E+VNMeYoOvAywl+hXEEF4CcqkrH/4iFMbzM8XXw==}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  array-buffer-byte-length@1.0.2:
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
+    engines: {node: '>= 0.4'}
+
+  arraybuffer.prototype.slice@1.0.4:
+    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
+    engines: {node: '>= 0.4'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  async-append-only-log@4.3.10:
+    resolution: {integrity: sha512-OYibcLkDBG9J8FFX4Nyf8RJOhO1EJTfCfb3rWou+qjcmuuJwBu7EuVVDpRtzJ+mPGVmwlXVPKtaw3X1lfHhxaQ==}
+
+  async-function@1.0.0:
+    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
+    engines: {node: '>= 0.4'}
+
+  async-single@1.0.5:
+    resolution: {integrity: sha512-I0SMZyvxwnr00advlzQbcfztaSEBv3Dw7Vg5i7pJVrXfjqHJSP1wljuOFKanBec5WKd+V4CIF4F9nhsukBikHA==}
+
+  atomic-file-rw@0.3.0:
+    resolution: {integrity: sha512-XMFpe/ub9Mwdlyq3DUdOc/g2sdutDMdYw0XNFSvNGQpYdmxqVmLbeklu5KhemUYyrAj1kIrwoHOx6IxA3a7w3A==}
+
+  atomic-file@2.1.1:
+    resolution: {integrity: sha512-Eh6pW+fRC2/1RxPq3hO8+PkZKv+wujzKky2MP/n69eC8yMkbNFfuEb/riZHqf13M7gr6Hvglpk/kISgBSBb6bQ==}
+
   attr-accept@2.2.5:
     resolution: {integrity: sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==}
     engines: {node: '>=4'}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  b4a@1.6.7:
+    resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -634,14 +690,54 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  base64-url@2.3.3:
+    resolution: {integrity: sha512-dLMhIsK7OplcDauDH/tZLvK7JmUZK3A7KiQpjNzsBrM6Etw7hzNI1tLEywqJk9NnwkgWuFKSlx/IUO7vF6Mo8Q==}
+    engines: {node: '>=6'}
+
+  bencode@2.0.3:
+    resolution: {integrity: sha512-D/vrAD4dLVX23NalHwb8dSvsUsxeRPO8Y7ToKA015JQYq69MLDOMkC0uGZYA/MPpltLO8rt8eqFC2j8DxjTZ/w==}
+
+  binary-search-bounds@2.0.5:
+    resolution: {integrity: sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA==}
+
   bip39@3.1.0:
     resolution: {integrity: sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==}
+
+  bipf@1.9.0:
+    resolution: {integrity: sha512-B/d8IADy5Y4v/CTMRWxLD8ONd2qRkF+2DbZLeIUql7PukfAiBhlGlw5qJcIU03l21qMEyvbi4PdntatH+j40vA==}
+
+  blake2b-wasm@2.4.0:
+    resolution: {integrity: sha512-S1kwmW2ZhZFFFOghcx73+ZajEfKBqhP82JMssxtLVMxlaPea1p9uoLiUZ5WYyHn0KddwbLc+0vh4wR0KBNoT5w==}
+
+  blake2b@2.1.4:
+    resolution: {integrity: sha512-AyBuuJNI64gIvwx13qiICz6H6hpmjvYS5DGkG6jbXMOT8Z3WUJ3V1X0FlhIoT1b/5JtHE3ki+xjtMvu1nn+t9A==}
 
   blake2s@1.1.0:
     resolution: {integrity: sha512-lvCxvg+up7AmujO8vijTi4GsbIOuusWa+b/nN5+VAanFjzbauq0er5VzgjTC6pevhEO8SYTzY784zS2KQauO0A==}
 
+  blake3@2.1.7:
+    resolution: {integrity: sha512-5d+TdKJvju96IyEaGJ0eO6CHbckWi+NBrCezGYM/WsnI3R03aLL2TWfsuZSh1rs0fTv/L3ps/r0vykjYurcIwA==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  buffer-alloc-unsafe@1.1.0:
+    resolution: {integrity: sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==}
+
+  buffer-alloc@1.2.0:
+    resolution: {integrity: sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==}
+
+  buffer-fill@1.0.0:
+    resolution: {integrity: sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==}
+
+  buffer-from@0.1.2:
+    resolution: {integrity: sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==}
+
+  buffer-xor@2.0.2:
+    resolution: {integrity: sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==}
+
+  buffer@5.1.0:
+    resolution: {integrity: sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -650,16 +746,40 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.8:
+    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
   canvas-confetti@1.9.3:
     resolution: {integrity: sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==}
+
+  chacha20-universal@1.0.4:
+    resolution: {integrity: sha512-/IOxdWWNa7nRabfe7+oF+jVkGjlr2xUL4J8l/OvzZhj+c9RpMqoo3Dq+5nU1j/BflRV4BKnaQ4+4oH1yBpQG1Q==}
 
   chai@5.2.1:
     resolution: {integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==}
     engines: {node: '>=18'}
 
+  charwise@3.0.1:
+    resolution: {integrity: sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw==}
+
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
+
+  chloride-test@1.2.4:
+    resolution: {integrity: sha512-9vhoi1qXSBPn6//ZxIgSe3M2QhKHzIPZQzmrZgmPADsqW0Jxpe3db1e7aGSRUMXbxAQ04SfypdT8dGaSvIvKDw==}
+
+  chloride@2.4.1:
+    resolution: {integrity: sha512-ZiID87W2o2llvuF4C7Fvt9GJisazSdMsSkjAq4WaMed9zn77nlkcy08ZfrPtOGAXyaxTDj0VjnuyD97EdJLz3g==}
 
   clarify-error@1.0.0:
     resolution: {integrity: sha512-f96oT3/Cdwz1eB+7RaH/XRR42lwGqVPnDl9NAm9ugT+BwAFoUS/pVnkgXUo/5UaUmwMMs6/GNFP8A8gCgmgvog==}
@@ -692,6 +812,13 @@ packages:
   continuable@1.2.0:
     resolution: {integrity: sha512-DMksZyrS34yEX+DTGyt9h8/6ONHRBH+PpQ5ev3YdCy5J41r0nMNv+psAujoeoT1mJf+fzKhzacR9o1M1ys2tBQ==}
 
+  cpu-percentage@1.0.3:
+    resolution: {integrity: sha512-LP7N2+hS7optwpkMisZoDfswnLeCzyETNOogkjw7v2YteQSPDd0vEv3nSbU8FVu58fXCkVAWtXaeSXEedT1a5g==}
+    engines: {node: '>=6.1'}
+
+  crc@3.6.0:
+    resolution: {integrity: sha512-K9CVP4+ugmpRvZidsumVVL1swX7t0cqYrLhT+5rAp7/S3TjiEtpovD8TISzy+3moanm6v6/cbXOzE6JbzB+siw==}
+
   cssstyle@4.6.0:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
     engines: {node: '>=18'}
@@ -702,6 +829,18 @@ packages:
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
+
+  data-view-buffer@1.0.2:
+    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-length@1.0.2:
+    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-offset@1.0.1:
+    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
+    engines: {node: '>= 0.4'}
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
@@ -719,16 +858,45 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  deep-equal@1.1.2:
+    resolution: {integrity: sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==}
+    engines: {node: '>= 0.4'}
+
   deferred-leveldown@5.3.0:
     resolution: {integrity: sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==}
     engines: {node: '>=6'}
     deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   discontinuous-range@1.0.0:
     resolution: {integrity: sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  dynamic-dijkstra@1.0.2:
+    resolution: {integrity: sha512-1N+eCCrepIeK1+qtWrMEO1CV68Hn+TLbiR9c70VB3xnut3DmUxT+3T7sRHhb0mpK2F/74IfP+loQDriU2W9lkA==}
+
+  ed2curve@0.1.4:
+    resolution: {integrity: sha512-hDZWhCHZ1wu4P2g2RVsM2MjDmmJzhvcsXr5qHUSBJZXvuhJSunhbVsWoBXdIe0/yTa3RV4UaWpOmFmrVsKr0wA==}
+
+  emoji-named-characters@1.0.2:
+    resolution: {integrity: sha512-F9uKjyRsj7qjqZh7yjgHYa7XCgJgGI+nHTUqxkq/TDGuq0wLFbUX0wNes3XC6OA2j2Uu8PaeZD6hvCu5eO3lTA==}
+    deprecated: This package is no longer maintained
+
+  emoji-server@1.0.0:
+    resolution: {integrity: sha512-v/PzC37CStc2L4VBhBTz7k4onQwIDlgHX+VBV+L6gzbdY+joukCssbS4aJ4Y7kD4XIsT0IKV3xewNsW+QQsSbg==}
 
   encoding-down@6.3.0:
     resolution: {integrity: sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==}
@@ -739,12 +907,45 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  envelope-js@1.3.2:
+    resolution: {integrity: sha512-U3MQnyczN9QvwgXWlxDzAiEbNjwGD1aG+l1fNdwSZijOYboiu1aLHT8vIPSITShLiD4+n9p+EEwR79rp0vsKdw==}
+
+  envelope-spec@1.1.1:
+    resolution: {integrity: sha512-7eIn5kw7eIt2H2YEPE5oWT8ATx9AYkVFKQi4GG+3qRxgcBKmPWt71OOI3DE4Do/hryZohh9eamoxGhSgZGQpIw==}
+
+  epidemic-broadcast-trees@9.0.4:
+    resolution: {integrity: sha512-f1Y2ayalcLQNn2I6umep29UDkTo+8nF4D//KulmwjDGP4ZPOO+ch8/LuxpXaMoeV6RO5arvvaEL53yzkKGSHTg==}
+
   errno@0.1.8:
     resolution: {integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==}
     hasBin: true
 
+  es-abstract@1.24.0:
+    resolution: {integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==}
+    engines: {node: '>= 0.4'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  es-to-primitive@1.3.0:
+    resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.25.8:
     resolution: {integrity: sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==}
@@ -754,9 +955,22 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
+
+  fast-varint@1.0.1:
+    resolution: {integrity: sha512-Vi9Db6dVe0GbWHtZxYzlpLbIq4o1FnVIaVud3RMYF/E7d4l0r37aepMY16qZBNfniw/o02BP9LAqCYCKjFTy+Q==}
+
+  fastintcompression@0.0.4:
+    resolution: {integrity: sha512-sRtejNHcWjJl0Fr+gsbybbgOKKj0sQYvv7rA787EbeFu1fMpmzjHuBW8fLBImSZeqDuR++TZU2n60mRrpAUR9g==}
+
+  fastpriorityqueue@0.7.5:
+    resolution: {integrity: sha512-3Pa0n9gwy8yIbEsT3m2j/E9DXgWvvjfiZjjqcJ+AdNKTAlVMIuFYrYG5Y3RHEM8O6cwv9hOpOWY/NaMfywoQVA==}
 
   fdir@6.4.6:
     resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
@@ -770,6 +984,22 @@ packages:
     resolution: {integrity: sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==}
     engines: {node: '>= 12'}
 
+  flumecodec@0.0.0:
+    resolution: {integrity: sha512-1UhNtCE8Al1mMrEqvRGxKU2GoZHXPKLWmAm6Oe2J9x+oQeMinCW9jpegJaEuGgUtro94MogbObFjEBFJHc36fA==}
+
+  flumecodec@0.0.1:
+    resolution: {integrity: sha512-JT0xivzdV7uTucjsLMw6JhK2e1K5TmU4fGmoQqnrJbydgY/V6+m71QoxX5ZtRR1pKoD48uhPDWWE6G5MlNoGkg==}
+
+  flumelog-offset@3.4.4:
+    resolution: {integrity: sha512-sakCD+dVx541h3VeVq3Ti2lWPRrJf8PBRmnbm9EMBVLJnZkS3UD2lAlClZROxgKbh/JkMPyffvhDGv4VHNCVbA==}
+
+  flumeview-reduce@1.4.0:
+    resolution: {integrity: sha512-ShCMtY5YZl3icnUAWTfwzRXSGN1AUo4Isj1wTRLpMMNgM9p1T0gc6N+r1ajampf1GO19SkqrgZHdPPOaEitvhg==}
+
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -778,13 +1008,91 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  function.prototype.name@1.1.8:
+    resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
+    engines: {node: '>= 0.4'}
+
+  functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  futoin-hkdf@1.5.3:
+    resolution: {integrity: sha512-SewY5KdMpaoCeh7jachEWFsh1nNlaDjNHZXWqL5IGwtpEYHTgkr2+AMCgNwKWkcc0wpSYrZfR7he4WdmHFtDxQ==}
+    engines: {node: '>=8'}
+
+  generate-function@2.3.1:
+    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+
+  generate-object-property@1.2.0:
+    resolution: {integrity: sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-symbol-description@1.1.0:
+    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
+    engines: {node: '>= 0.4'}
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  gossip-query@2.0.2:
+    resolution: {integrity: sha512-17MflOq79BYcK01RrqHhtG5Dl88ztSu7gfD+4i1GrpzkbvLDKkJ7LoKiFKzBWzzd+Jd5VhIiLtQRvjRiKa6PUg==}
+
+  has-bigints@1.1.0:
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>= 0.4'}
+
+  has-network2@0.0.3:
+    resolution: {integrity: sha512-EvEZguA+LkyiS8G/Qks5I6imKnM2Z3NPN3eoQhviUQ7O6/d8nyZ7sDozBk6kTIA+Qj/S/V8ubRA1rqJcxc3qBQ==}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-proto@1.2.0:
+    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hashlru@2.3.0:
+    resolution: {integrity: sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  heap@0.2.7:
+    resolution: {integrity: sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==}
+
+  hoox@0.0.1:
+    resolution: {integrity: sha512-4tKFjXcp8AWuw5lLTL7Xnixj1w88r+y1j9HKE8GoSeqDfsv6fLNMLjnrkB/H9tH+LqLp4+7eLss5IFS3Qra4lw==}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
@@ -802,11 +1110,17 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  idb-kv-store@4.5.0:
+    resolution: {integrity: sha512-snvtAQRforYUI+C2+45L2LBJy/0/uQUffxv8/uwiS98fSUoXHVrFPClgzWZWxT0drwkLHJRm9inZcYzTR42GLA==}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   immediate@3.3.0:
     resolution: {integrity: sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==}
+
+  increment-buffer@1.0.1:
+    resolution: {integrity: sha512-djREfebnCm+rsaMKhxQ3iQI0uUicnKoWUt3eHBLAMqqh9PRJYb+gc2Sty7HYpXrE0JdgdND/wNZIqOyUcMdejw==}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -815,23 +1129,155 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  int53@1.0.0:
+    resolution: {integrity: sha512-u8BMiMa05OPBgd32CKTead0CVTsFVgwFk23nNXo1teKPF6Sxcu0lXxEzP//zTcaKzXbGgPDXGmj/woyv+I4C5w==}
+
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
+
+  ip-address@9.0.5:
+    resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
+    engines: {node: '>= 12'}
+
   ip@1.1.9:
     resolution: {integrity: sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==}
+
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
+  is-array-buffer@3.0.5:
+    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
+    engines: {node: '>= 0.4'}
+
+  is-async-function@2.1.1:
+    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
+    engines: {node: '>= 0.4'}
+
+  is-bigint@1.1.0:
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+    engines: {node: '>= 0.4'}
+
+  is-boolean-object@1.2.2:
+    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
+    engines: {node: '>= 0.4'}
+
+  is-buffer-zero@1.0.0:
+    resolution: {integrity: sha512-eqgpqrTMGaAd5dQxg0dcZ79C8wTlDVYrM+zvB8kUXXSBzOqG5JeKWne1Zv9LDV3ePovx06fHLbp372OFbp/cIA==}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
 
   is-canonical-base64@1.1.1:
     resolution: {integrity: sha512-o6t/DwgEapC0bsloqtegAQyZzQXaQ5+8fzsyf2KmLqupC2ifLFq/lMQiFCJeGpdSrK1o6GL+WW2lRU050lLlFg==}
 
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
+
+  is-data-view@1.0.2:
+    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
+    engines: {node: '>= 0.4'}
+
+  is-date-object@1.1.0:
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
+    engines: {node: '>= 0.4'}
+
+  is-finalizationregistry@1.1.1:
+    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
+    engines: {node: '>= 0.4'}
+
+  is-generator-function@1.1.0:
+    resolution: {integrity: sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==}
+    engines: {node: '>= 0.4'}
+
+  is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-my-ip-valid@1.0.1:
+    resolution: {integrity: sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==}
+
+  is-my-json-valid@2.20.6:
+    resolution: {integrity: sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==}
+
+  is-my-ssb-valid@1.2.2:
+    resolution: {integrity: sha512-13B1KdYuXwfVASWWWAKcbtKHtXhFNzLtg16oKh/3UTAWVh9GBdf/zjvY9BFY3xYsYFQYC1WhZEuifbYRzeiz7w==}
+
+  is-negative-zero@2.0.3:
+    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
+    engines: {node: '>= 0.4'}
+
+  is-number-object@1.1.1:
+    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
+    engines: {node: '>= 0.4'}
+
+  is-options@1.0.2:
+    resolution: {integrity: sha512-u+Ai74c8Q74aS8BuHwPdI1jptGOT1FQXgCq8/zv0xRuE+wRgSMEJLj8lVO8Zp9BeGb29BXY6AsNPinfqjkr7Fg==}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-property@1.0.2:
+    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
+
+  is-shared-array-buffer@1.0.4:
+    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
+    engines: {node: '>= 0.4'}
+
+  is-string@1.1.1:
+    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
+    engines: {node: '>= 0.4'}
+
+  is-symbol@1.1.1:
+    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
+    engines: {node: '>= 0.4'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
   is-valid-domain@0.0.20:
     resolution: {integrity: sha512-Yd9oD7sgCycVvH8CHy5U4fLXibPwxVw2+diudYbT8ZfAiQDtW1H9WvPRR4+rtN9qOll+r+KAfO4SjO28OPpitA==}
+
+  is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakref@1.1.1:
+    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
+    engines: {node: '>= 0.4'}
+
+  is-weakset@2.0.4:
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
+    engines: {node: '>= 0.4'}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
+  jitdb@7.0.7:
+    resolution: {integrity: sha512-D/b1uyZzEvQewg9gDamgkCjvCji3ZYnirG86p3VHm/UzCohASd6ojLZrRPZHlsDRWsO5qhZxBzWoH7fSRtztdA==}
+    peerDependencies:
+      async-append-only-log: ^4.3.2
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsbn@1.1.0:
+    resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
 
   jsdom@26.1.0:
     resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
@@ -841,6 +1287,28 @@ packages:
     peerDependenciesMeta:
       canvas:
         optional: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json-buffer@2.0.11:
+    resolution: {integrity: sha512-Wu4/hxSZX7Krzjor+sZHWaRau6Be4WQHlrkl3v8cmxRBBewF2TotlgHUedKQJyFiUyFxnK/ZlRYnR9UNVZ7pkg==}
+
+  jsonpointer@5.0.1:
+    resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
+    engines: {node: '>=0.10.0'}
+
+  key-value-file-store@1.1.1:
+    resolution: {integrity: sha512-j2Vq2ftRSt99InoUUvMBgLX6BLrHZSa8nedntZyhqj2njzBaeL3IiUpT3DYx2p2+Fbf4vcmn74rJcds0uGpc0g==}
+
+  layered-graph@1.2.0:
+    resolution: {integrity: sha512-VnjZHUyaXXsOR6KZ8JjTbkyjtq8VaU5ncGJ8cKBvg2bSLqVHE4bcGJ+20dDE7T84sss9d/BCHRj34Yh2fz9sbg==}
+
+  level-codec@6.2.0:
+    resolution: {integrity: sha512-J437PvCMZZKNT88+VRh6dkmh1ndZzwGwDzb5ZZl3QEsl+U9wIlt8hG+Y1gXVOhH75gf8JyceKGiG6WFUBbxyGQ==}
+    deprecated: Superseded by level-transcoder (https://github.com/Level/community#faq)
 
   level-codec@9.0.2:
     resolution: {integrity: sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==}
@@ -891,6 +1359,15 @@ packages:
     engines: {node: '>=6'}
     deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
 
+  libsodium-wrappers@0.7.15:
+    resolution: {integrity: sha512-E4anqJQwcfiC6+Yrl01C1m8p99wEhLmJSs0VQqST66SbQXXBoaJY0pF4BNjRYa/sOQAxx6lXAaAFIlx+15tXJQ==}
+
+  libsodium@0.7.15:
+    resolution: {integrity: sha512-sZwRknt/tUpE2AwzHq3jEyUU5uvIZHtSssktXq7owd++3CSgn8RGrv6UZJJBpP7+iBghBqe7Z06/2M31rI2NKw==}
+
+  lodash.debounce@4.0.8:
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
   looper@2.0.0:
     resolution: {integrity: sha512-6DzMHJcjbQX/UPHc1rRCBfKlLwDkvuGZ715cIR36wSdYqWXFT35uLXq5P/2orl3tz+t+VOVPxw4yPinQlUDGDQ==}
 
@@ -921,13 +1398,33 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
+  map-merge@1.1.0:
+    resolution: {integrity: sha512-TGNNg3WqoLsS5HnlK6GHIXFvM/0wYMtlyflc1nAQUhgptr9wIu7JwQ2YsqnpFSqbSYFv2U6rgXQTHJmWJOtlzQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mkdirp@0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
 
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
+
+  monotonic-timestamp@0.0.9:
+    resolution: {integrity: sha512-PQcys7iTcXiMyW8cgK5B/fhKGteB/WLqWN1f+s7IJHyyRd80JnJYoNo03kTQcGZhVtsKz5kEWiS7W94gfY6qcQ==}
 
   moo@0.5.2:
     resolution: {integrity: sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==}
@@ -935,11 +1432,37 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  multiblob-http@1.2.1:
+    resolution: {integrity: sha512-ZNgfHZkC1A1xec7aUE7Tq6ArIXE7pygzbf3jNX1wlK15STqenGGURrqM79puk3j2cscC9Keu/ULQM3dET3xLCQ==}
+    engines: {node: '>=12'}
+
   multiblob@1.13.8:
     resolution: {integrity: sha512-YXNUflHc7I7iUiLctHMTvwDQOjMbCv+Pdbf+1lScFOsjP/CSZgwblRknPntcD+KEPGFudXPBtJR10TIrun3zmQ==}
 
+  multicb@1.2.2:
+    resolution: {integrity: sha512-PZM4dhYFmCF6uZGWpEmoPMUqJBywS9IcAgybT2GmSpYI1BvGvoWSdbio+ik+q/YD2vodhvslESWIS3NnkKYdqQ==}
+
   multiserver-address@1.0.1:
     resolution: {integrity: sha512-IfZMAGs9onCLkYNSnNBri3JxuvhQYllMyh3W9ry86iEDcfW9uPVsHTHDsjDxQtL+dPq3byshmA+Y4LN2wLHwNw==}
+
+  multiserver-scopes@2.0.0:
+    resolution: {integrity: sha512-XWv9J617i3mWtZIZQNTpYI9iq4goUpsKy3GdUEDls23z1VaMzuRp2rL3S3IKrheVdgmrf0zHbErcXokGxqQfzw==}
+
+  multiserver@3.8.2:
+    resolution: {integrity: sha512-gmR/5dY+N81EN0yDaziSJXAJhJjG+3Rv3lJc74OSA1ySRKOMqZwEuGJjqG6ZcZiaqcHvhQZkZavDJsAwtmnvoA==}
+    engines: {node: '>=12'}
+
+  mutexify@1.4.0:
+    resolution: {integrity: sha512-pbYSsOrSB/AKN5h/WzzLRMFgZhClWccf2XIB4RSMC8JbquiB0e0/SH5AIfdQMdyHmYtv4seU7yV/TvAwPLJ1Yg==}
+
+  muxrpc@6.7.3:
+    resolution: {integrity: sha512-yVr66BigJxHIvHOLsdJzuvrHt46Vq9DiDCBTZiS6q+49mXh4mkDjRiXo9FnGXQv1WJOqnRJk5fcfwV6TaSgNvA==}
+
+  nano-equal@2.0.2:
+    resolution: {integrity: sha512-RtAioZtSSppEWRruYU8oz2AKPJWTW74TpzcqP79n7Kh4nHW+gmrJGcTuELmid9tvGR4Xp2cCoTtYIIDy9iWO4g==}
+
+  nanoassert@2.0.0:
+    resolution: {integrity: sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -953,8 +1476,19 @@ packages:
     resolution: {integrity: sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==}
     hasBin: true
 
+  next-tick@1.1.0:
+    resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
+
   node-gyp-build@4.1.1:
     resolution: {integrity: sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ==}
+    hasBin: true
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
+  non-private-ip@2.2.0:
+    resolution: {integrity: sha512-NZ3Upr3K2whD6vdZ9k8gHsijsrQl5O6IARLIUDyvQwSuO/owM1kOMu8wDMMsIR8ujlLvhPNjlTZC2SXzWwWByQ==}
     hasBin: true
 
   normalize-wheel@1.0.1:
@@ -967,11 +1501,52 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
+  obv@0.0.1:
+    resolution: {integrity: sha512-Iq/Q3TXAfHgABGL7mKlG3ILJnT8jgetOt0sH9a6SGLLCvjh58bsH7RzixLJWkVO6aQK6hI4rxVYHF0rk9KmIwA==}
+
   obz@1.1.1:
     resolution: {integrity: sha512-eUiAX663dASOUIEWuRzUycf2ERZJFLbdjfzYRtju9z2eBfDPywcWjfyHV5JNbVoBjuHGVodyfeyy8Qu09+JCXw==}
 
+  on-change-network-strict@1.0.0:
+    resolution: {integrity: sha512-ldHCpTJWgr5KUJy3/TVoSGNwBUA8BP9UFmd0iQqe4aGaXY4PJyzQPiVBIo8VBSlSoKyaJY3vcpW0hixZb6gPaA==}
+
+  on-wakeup@1.0.1:
+    resolution: {integrity: sha512-3ufOvnTvh39ah2/TT++HpLailHVmEVVrKtzKLKifAUyWbulKLGGJGOF7ywKC4k/iQGmn9KooV6WmQl/6BVwklA==}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  own-keys@1.0.1:
+    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
+    engines: {node: '>= 0.4'}
+
+  p-defer@3.0.0:
+    resolution: {integrity: sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==}
+    engines: {node: '>=8'}
+
+  packet-stream-codec@1.2.0:
+    resolution: {integrity: sha512-3xoTsSVqCPd+0mPsQGlfYm2ecvJK9tS1HOxrjnKEiB1Ynq0fOJHEXcZV/hxW6BkOSGBsGX7dTN8bjdNTU3nKBA==}
+    engines: {node: '>=12'}
+
+  packet-stream@2.0.6:
+    resolution: {integrity: sha512-kSxHpoTqlgNEetMp77snCTVILwLw4dJX6pB/z1g1PRG5xylH8cf9upIPygt+epBC3l14XrcZH4/kQYSrzp2Ijg==}
+    engines: {node: '>=8'}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -979,6 +1554,9 @@ packages:
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -994,9 +1572,33 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  polyraf@1.1.0:
+    resolution: {integrity: sha512-wKRyhZQE6AC70nJyMCWbwd/dX4S6UsFz+58qAF8HTpCn6C7pvr63FiH4vR9vT6VrhZrJKuT7A81ea/lIslS0bA==}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  private-box@0.3.1:
+    resolution: {integrity: sha512-abAuk3ZDyQvPLY6MygtwaDTUBIZ0C5wMMuX1jXa0svazV+keTwn7cPobRv4WYA9ctsDUztm/9CYu4y2TPL08xw==}
+
+  private-group-spec@1.2.0:
+    resolution: {integrity: sha512-O7SfG+vZIZgqDXy/wjsuTRI5LaozW4rxaZBpGmwlcDfjIvxvYWNboyNm1PoQUU6j4dQ02V1tOQVLDq9u2RzolA==}
+
+  promisify-4loc@1.0.0:
+    resolution: {integrity: sha512-u/XtndUyqqDXAuhFEgFgkpjHG8IizREoj80j5dL4t41eE9yH0gzFPyOD21/VnikdPJtRziuqf6ryTu1HoTjyog==}
+    engines: {node: '>=6'}
+
+  promisify-tuple@1.2.0:
+    resolution: {integrity: sha512-DRI8QrLUzbQxgwLiwKhtVCpSqtAUnnyPaCi3cad2+0avb2o5UzobLWHkXUOAYQB8e4fSJVef22eVm77c/8n//g==}
+    engines: {node: '>=6'}
+
+  promisize@1.1.2:
+    resolution: {integrity: sha512-6/X05CD1iri6YyLy6TW7a23HY0igsrb/qetltYKfJznLfzmspWtN/cY/UR0By3M5i13hBDWfmM2P42ovKl3GAw==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -1004,20 +1606,44 @@ packages:
   prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
 
+  pull-abortable@4.1.1:
+    resolution: {integrity: sha512-/zz8tW+T5tvtDc4NQVZTp3lJZoGEpUb2VDV3R5Q2/9lavNTwHK+hC5yF/3Q3LMmdn5AluFy23RFoqXIoySPl1w==}
+
+  pull-async@1.0.0:
+    resolution: {integrity: sha512-mm0mZe9tb3yjIhfXt384c8EXGFAtMbau20At2yNqZDPXHevjrfom5b82sk8BMQfGhj6gXimnOde1lhUKkF/v9w==}
+
+  pull-awaitable@1.0.0:
+    resolution: {integrity: sha512-tfufzU9wMd1rM38tcgunaKMUNGXMj1Qms1ygEw+ZerkMmLAwilEtMsyzrDSLhNlnfhSzHXovOarieSNrTD1ovQ==}
+
+  pull-box-stream@1.0.13:
+    resolution: {integrity: sha512-OPg5cTnBCH9jpTCNZfm+BrtrAzmu5NsWDyDadaWiB06oWQujSMfRJp58VqhuJOCEgxVkeKFhXTaSKE+StNKRHw==}
+
   pull-cat@1.1.11:
     resolution: {integrity: sha512-i3w+xZ3DCtTVz8S62hBOuNLRHqVDsHMNZmgrZsjPnsxXUgbWtXEee84lo1XswE7W2a3WHyqsNuDJTjVLAQR8xg==}
 
   pull-catch@1.1.0:
     resolution: {integrity: sha512-x6DkWZfBVvYrjUIcFroe3GtBkZcRINi8PsYgx3qBYluIeawLn4Z5oJI++WE5AJPbIZBmxHFx+zIvQmhRYaSeFA==}
 
+  pull-cont@0.1.1:
+    resolution: {integrity: sha512-OAJRFBoEW00F0++qkeNuIWdaUwqrlZGj/6JAm+094iWKDnuzBXUWi2IipDqNa+yzIJrOE8BjwugiyGtLvPAk4w==}
+
+  pull-cursor@3.0.0:
+    resolution: {integrity: sha512-95lZVSF2eSEdOmUtlOBaD9p5YOvlYeCr5FBv2ySqcj/4rpaXI6d8OH+zPHHjKAf58R8QXJRZuyfHkcCX8TZbAg==}
+
   pull-defer@0.2.3:
     resolution: {integrity: sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA==}
+
+  pull-drain-gently@1.1.0:
+    resolution: {integrity: sha512-ZUPsNrn8jkU6Y2B4w8Jz3gXAmjSpb+qn4AQhAL8qTWUHULglH16ANr+6qnfOEa1kUoUGVCQZaORTd2NSQFAnhA==}
 
   pull-file@0.5.0:
     resolution: {integrity: sha512-4s/IfBLebH/eWUlhp3F3M29mk+B1cryp3W99t/k9J/c033f+HyLLVB2EAMGoN02j8ff7ObkLF1tMaHok3nGS6Q==}
 
   pull-file@1.1.0:
     resolution: {integrity: sha512-yP3hNN3C0PrxA5isqyzHvsvFxd7Ohjvp4aLreeHm8mhnipxUfbY08Mk7o/KDsnR8N4WT9W3CqMDysU+ZufMr6w==}
+
+  pull-flatmap@0.0.1:
+    resolution: {integrity: sha512-9BgwZPZ6J22kPf9ExoVI3m2yMHdCK8uPf58p6L63t36IgH7NrCX+p3QV8cQ4JmYjwvXDZzimVuJ7IW7iLxm7cA==}
 
   pull-fs@1.1.6:
     resolution: {integrity: sha512-xO+d44h/FdlSW61RpxUdqLhNz5vHKnjqEyGaXIVvZa5TxkOvIzhkWd7BXqH8oakXCxb8NozN6F/w1BtfP8Z64Q==}
@@ -1026,29 +1652,68 @@ packages:
     resolution: {integrity: sha512-nQrhcraiOUfMYiFoJyGLICb5AzlmWm5Vzwhqt+wNuimCG1kqrjdWycw5Dk9xQbHYbq5U55hs3Hee0qZgpjZ3bA==}
     hasBin: true
 
+  pull-goodbye@0.0.3:
+    resolution: {integrity: sha512-fl3RcIHKsxFaygdU3dcwSznLr73HYGOEU9IshpiatYSV+PW3TOUEjtfdu1L8uIsUoDajJz3HM/+mG0mFD4+v5A==}
+
+  pull-handshake@1.1.4:
+    resolution: {integrity: sha512-+dT8auWatbSNt1o43GKygECvOM2znXdyWwhEQaxztJSvxrNtEqo/wgZttknLfyxxbkbS6qUten6LsXTOwYj0yg==}
+
+  pull-inactivity@2.1.4:
+    resolution: {integrity: sha512-W2Q+6Jk0oRMICYXBXom3/ipz2U5YPUSQUfLvVgUqL/daHop7QQB3Jz5XpnnxsekCPoM61lGvXc7kFDZt0uWzMg==}
+
   pull-level@2.0.4:
     resolution: {integrity: sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==}
 
   pull-live@1.0.1:
     resolution: {integrity: sha512-tkNz1QT5gId8aPhV5+dmwoIiA1nmfDOzJDlOOUpU5DNusj6neNd3EePybJ5+sITr2FwyCs/FVpx74YMCfc8YeA==}
 
+  pull-looper@1.0.0:
+    resolution: {integrity: sha512-djlD60A6NGe5goLdP5pgbqzMEiWmk1bInuAzBp0QOH4vDrVwh05YDz6UP8+pOXveKEk8wHVP+rB2jBrK31QMPA==}
+
+  pull-many@1.0.9:
+    resolution: {integrity: sha512-+jUydDVlj/HsvtDqxWMSsiRq3B0HVo7RhBV4C0p2nZRS3mFTUEu9SPEBN+B5PMaW8KTnblYhTIaKg7oXgGnj4Q==}
+
   pull-notify@0.1.2:
     resolution: {integrity: sha512-oooAxYEUGNbOVsUrmqqTWWsAUMRIs4sYglnxgleiVcWyvrWgOuk/WUoZDajPTsYix2/rd+z5xSclzHLA7QygcQ==}
+
+  pull-pair@1.1.0:
+    resolution: {integrity: sha512-7VEFLxWnj2AKaN3AvtyaM508d1+56/ulSjDLu4j6kcd9DnEM6LfG8b1R9gCLqzIjJo5stFrWynVc6e451OW4LQ==}
 
   pull-paramap@1.2.2:
     resolution: {integrity: sha512-0ALwLcASif3KmKCXO4liySCKsTfC/mGYhRFch+xLvfJJrYOIfXPthrykDUZpeZtbjEXglPySzfUmYcnBqzTj5w==}
 
+  pull-pause@0.0.2:
+    resolution: {integrity: sha512-yQs63NDgD/FeAsdF7INpy4uDolkstkS4Gx1Z3BvMR2gQS8RREJd2tsy6d/K6T+/CDStGnCQI7JLrkjz10YNiSA==}
+
+  pull-ping@2.0.3:
+    resolution: {integrity: sha512-nbY4yHnMesJBrvkbhMim4VXUC9k1VCkgrkQu49pf8mxFbmb/U2KQrsuePvSmLjRL+VgkBVRSUXUoOY7DtSvhKw==}
+
   pull-pushable@2.2.0:
     resolution: {integrity: sha512-M7dp95enQ2kaHvfCt2+DJfyzgCSpWVR2h2kWYnVsW6ZpxQBx5wOu0QWOvQPVoPnBLUZYitYP2y7HyHkLQNeGXg==}
 
+  pull-rate@1.0.2:
+    resolution: {integrity: sha512-HH4fXHM7gu2uCO6u2SqTuGGDqPZNVHKXjTdyP9igg8jAROnvSph9plMAQqmv4elYFCm+Bfah2ASGWWe/+NdzMQ==}
+
+  pull-reader@1.3.1:
+    resolution: {integrity: sha512-CBkejkE5nX50SiSEzu0Qoz4POTJMS/mw8G6aj3h3M/RJoKgggLxyF0IyTZ0mmpXFlXRcLmLmIEW4xeYn7AeDYw==}
+
   pull-stream@3.7.0:
     resolution: {integrity: sha512-Eco+/R004UaCK2qEDE8vGklcTG2OeZSVm1kTUQNrykEjDwcFXDZhygFDsW49DbXyJMEhHeRL3z5cRVqPAhXlIw==}
+
+  pull-thenable@1.0.0:
+    resolution: {integrity: sha512-gio2Yanuj5lcN8X+VXtx6F2iWxnhxfaHSKaSJHUzJMNNboEz48/+udzZFDaya8kAwj3DbuFFt1pbb8m1tIS6PQ==}
+
+  pull-through@1.0.18:
+    resolution: {integrity: sha512-t8BBRdKstI/JoWS3FAXRnBvo1ahoLcKo8nm8ZUzr4OUgIf47RodD6HjnPIpw/d6HQZaMu+TotLAYCNwLTnvcNw==}
 
   pull-traverse@1.0.3:
     resolution: {integrity: sha512-tdvTsDPh7PwuBEJ3o7DI6h/bQ5ocm9W0TYWNWEQ37ZS9Mt9aRfJqfvmAIdrpg3DgahU9PSITX0fYg8xTbqEdjQ==}
 
   pull-utf8-decoder@1.0.2:
     resolution: {integrity: sha512-hpGheDlDMMEOkiBwXpiUqaFVR0SlGb23vZyJuHe1s8CWGJVcDEzhy9HHUEIuPjTEajYb90ikKsDmt6lkmTtk5g==}
+
+  pull-websocket@3.4.2:
+    resolution: {integrity: sha512-hGFWC4/fzRdO2FEsyR9woVzgv/yG4PIk3RXPN4azBpomGzGQFRUORwKQDS3j7RAIy8tjvN2W+qjU8jNn2NWeNQ==}
 
   pull-window@2.1.4:
     resolution: {integrity: sha512-cbDzN76BMlcGG46OImrgpkMf/VkCnupj8JhsrpBw3aWBM9ye345aYnqitmZCgauBkc0HbbRRn9hCnsa3k2FNUg==}
@@ -1063,9 +1728,21 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  push-stream-to-pull-stream@1.0.5:
+    resolution: {integrity: sha512-oQfzDroAv+SySQIXFiBVkShIh8Vgpr+hd7TrwyUna1kVrbv3i6D+QQC+31QdI7D6Jow61QLQW+uWToxv4cXI2w==}
+
+  push-stream@11.2.0:
+    resolution: {integrity: sha512-MbiU+tFKDFv6IRwxfU2pltftFiIsW6mhLT3q91EJQwZYd2A9aaytdKAnRGYCx9KAuWQ11/cClK/FvHY996WwxA==}
+
+  queue-tick@1.0.1:
+    resolution: {integrity: sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==}
+
   quick-lru@7.0.1:
     resolution: {integrity: sha512-kLjThirJMkWKutUKbZ8ViqFc09tDQhlbQo2MNuVeLWbRauqYP96Sm6nzlQ24F0HFjUNZ4i9+AgldJ9H6DZXi7g==}
     engines: {node: '>=18'}
+
+  quicktask@1.0.1:
+    resolution: {integrity: sha512-+jhR01aSsi6Iw9wbYumKusRK72QK1ub2oE0kOnRyMkMdD/rXMMGW/TVl5edjcLjuuIKP1ezkr+xQzUMD5/4JHw==}
 
   railroad-diagrams@1.0.0:
     resolution: {integrity: sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==}
@@ -1073,6 +1750,34 @@ packages:
   randexp@0.4.6:
     resolution: {integrity: sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==}
     engines: {node: '>=0.12'}
+
+  random-access-chrome-file@1.2.0:
+    resolution: {integrity: sha512-M1NOdkHEcjRB+acKrdQkwf8aMTnZUIGboiH6i2PMNkjfChBIJiB4j4MuhpOn+u+XU2n7GqpocPN4bzfv0jrBsg==}
+
+  random-access-file@2.2.1:
+    resolution: {integrity: sha512-RGU0xmDqdOyEiynob1KYSeh8+9c9Td1MJ74GT1viMEYAn8SJ9oBtWCXLsYZukCF46yududHOdM449uRYbzBrZQ==}
+
+  random-access-idb-mutable-file@0.3.0:
+    resolution: {integrity: sha512-CdVAoFNNDn5uAgYOJ8J3ICSaFzaMOa95XnYcX+taj4jirJuRASiTyQSOGR+Z0K8ZkBGuj0A8ivyeRAWuxRCgQA==}
+
+  random-access-idb@1.2.2:
+    resolution: {integrity: sha512-NroFuBNVh5wVIHKN/jEYrgkkffppkfxNWFX9OEwC2VP7dYc3sa+Qxv7tMa1Gi9Jp/ObVfLeCZBt/8Sbn1WU1Xg==}
+
+  random-access-memory@3.1.4:
+    resolution: {integrity: sha512-rqgqd/8ec65gbpKaYHnDOW391OR39d+eXn8NI87G+f3sUKrtGib9jC+/5/9MBFBwwHAZIS8RLJ8yyB4etzbYTA==}
+
+  random-access-storage@1.3.0:
+    resolution: {integrity: sha512-pdS9Mcb9TB7oICypPRALlheaSuszuAKmLVEPKJMuYor7R/zDuHh5ALuQoS+ox31XRwQUL+tDwWH2GPdyspwelA==}
+
+  random-access-storage@1.4.3:
+    resolution: {integrity: sha512-D5e2iIC5dNENWyBxsjhEnNOMCwZZ64TARK6dyMN+3g4OTC4MJxyjh9hKLjTGoNhDOPrgjI+YlFEHFnrp/cSnzQ==}
+
+  random-access-web@2.0.3:
+    resolution: {integrity: sha512-nN3AAgl4/lTOYMk5Qm44SzFsglOmaG2d0Kh0603umh35+rk9QXYLFf0nFJ0GOv9INBsP9iT1lub24r8PjyCtvA==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
 
   react-dom@19.1.1:
     resolution: {integrity: sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==}
@@ -1132,6 +1837,22 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  reflect.getprototypeof@1.0.10:
+    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
+    engines: {node: '>= 0.4'}
+
+  regexp.prototype.flags@1.5.4:
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
+    engines: {node: '>= 0.4'}
+
+  relative-url@1.0.2:
+    resolution: {integrity: sha512-jI1AmBVFFMXwQ3I6tIYVmVOjy8f+ogHbqkeb8/LL9tszEQiTV8I0l8XT4oEomUOoxfm698f92gYlNKeA/9LJVQ==}
+
+  resolve@1.22.10:
+    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
   ret@0.1.15:
     resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
     engines: {node: '>=0.12'}
@@ -1141,6 +1862,9 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  rng@0.2.2:
+    resolution: {integrity: sha512-3F/A3swXdqb4JLpF22zwlCllyXlUWEE3T35GzJ+Vvtx4HnUYVAXovaK2TyUC04UlpxdVxB+E7HaKdDrGeOcJuA==}
+
   rollup@4.46.2:
     resolution: {integrity: sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1149,11 +1873,29 @@ packages:
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
+  rwlock@5.0.0:
+    resolution: {integrity: sha512-XgzRqLMfCcm9QfZuPav9cV3Xin5TRcIlp4X/SH3CvB+x5D2AakdlEepfJKDd8ByncvfpcxNWdRZVUl38PS6ZJg==}
+
+  safe-array-concat@1.1.3:
+    resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
+    engines: {node: '>=0.4'}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safe-push-apply@1.0.0:
+    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
+    engines: {node: '>= 0.4'}
+
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sanitize-filename@1.6.3:
+    resolution: {integrity: sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -1162,33 +1904,283 @@ packages:
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
+  secret-handshake@1.1.21:
+    resolution: {integrity: sha512-e02+IddZv40tNJmaRZNZ6aYje95h9MvmpmbOg2PVjLKRA5p9QnrQypJlVE2dU516TyYc9jikBjqhXV1IlkwNUw==}
+
+  secret-stack-decorators@1.1.0:
+    resolution: {integrity: sha512-wYl0Mcul/fuEbZwn9tN62c+W4LP2RPus/ilt3wdBNQqfBFSMlDXTLaIsrA4SEElb7JEBH4xzdQbOCnTvYHeWCA==}
+
+  secret-stack@6.4.2:
+    resolution: {integrity: sha512-aUJNQ1DmZo0loxcnHOU7pvu9N2aOE0H63a1hpd77+I1GbmDBkK5hI9vO16IFf4OYDgPBiBIY3NGAHF23sdJC8g==}
+    engines: {node: '>=5.10.0'}
+
+  separator-escape@0.0.1:
+    resolution: {integrity: sha512-daCzTzZVoowYzjW7x9xMH6zr+lt/zsGxV1rtXaoTnlues7ZDx6Qu0l5W3jCdgnXGE1ONAGL+XPWY+IRDxnJ9EQ==}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
+
+  set-proto@1.0.0:
+    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
+    engines: {node: '>= 0.4'}
+
+  sha.js@2.4.12:
+    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
+    engines: {node: '>= 0.10'}
+    hasBin: true
+
+  sha.js@2.4.5:
+    resolution: {integrity: sha512-459AP5kwdIhtMLLE1+h2q5a6E7hyY7Ri88GUIhFsyrQinKkm+7qj1ARHELow7GkFS7oimWmIwhXTSxBsuNuOsw==}
+    hasBin: true
+
+  sha256-universal@1.2.1:
+    resolution: {integrity: sha512-ghn3muhdn1ailCQqqceNxRgkOeZSVfSE13RQWEg6njB+itsFzGVSJv+O//2hvNXZuxVIRyNzrgsZ37SPDdGJJw==}
+
+  sha256-wasm@2.2.2:
+    resolution: {integrity: sha512-qKSGARvao+JQlFiA+sjJZhJ/61gmW/3aNLblB2rsgIxDlDxsJPHo8a1seXj12oKtuHVgJSJJ7QEGBUYQN741lQ==}
+
+  sha512-universal@1.2.1:
+    resolution: {integrity: sha512-kehYuigMoRkIngCv7rhgruLJNNHDnitGTBdkcYbCbooL8Cidj/bS78MDxByIjcc69M915WxcQTgZetZ1JbeQTQ==}
+
+  sha512-wasm@2.3.4:
+    resolution: {integrity: sha512-akWoxJPGCB3aZCrZ+fm6VIFhJ/p8idBv7AWGFng/CZIrQo51oQNsvDbTSRXWAzIiZJvpy16oIDiCCPqTe21sKg==}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  siphash24@1.3.1:
+    resolution: {integrity: sha512-moemC3ZKiTzH29nbFo3Iw8fbemWWod4vNs/WgKbQ54oEs6mE6XVlguxvinYjB+UmaE0PThgyED9fUkWvirT8hA==}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks@2.8.6:
+    resolution: {integrity: sha512-pe4Y2yzru68lXCb38aAqRf5gvN8YdjP1lok5o0J7BOHljkyCGKVz7H3vpVIXKD27rj2giOJ7DwVyk/GWrPHDWA==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sodium-browserify-tweetnacl@0.2.6:
+    resolution: {integrity: sha512-ZnEI26hdluilpYY28Xc4rc1ALfmEp2TWihkJX6Mdtw0z9RfHfpZJU7P8DoKbN1HcBdU9aJmguFZs7igE8nLJPg==}
+
+  sodium-browserify@1.3.0:
+    resolution: {integrity: sha512-1KRS6Oew3X13AIZhbmGF0YBdt2pQdafJMfv83OZHWbzxG92YBBnN8HYx/VKmYB4xCe90eidNaDJWBEFw/o3ahw==}
+
+  sodium-chloride@1.1.2:
+    resolution: {integrity: sha512-8AVzr9VHueXqfzfkzUA0aXe/Q4XG3UTmhlP6Pt+HQc5bbAPIJFo7ZIMh9tvn+99QuiMcyDJdYumegGAczl0N+g==}
+
+  sodium-javascript@0.8.0:
+    resolution: {integrity: sha512-rEBzR5mPxPES+UjyMDvKPIXy9ImF17KOJ32nJNi9uIquWpS/nfj+h6m05J5yLJaGXjgM72LmQoUbWZVxh/rmGg==}
+
+  sodium-native@3.4.1:
+    resolution: {integrity: sha512-PaNN/roiFWzVVTL6OqjzYct38NSXewdl2wz8SRB51Br/MLIJPrbM3XexhVWkq7D3UWMysfrhKVf1v1phZq6MeQ==}
+
+  sodium-universal@3.1.0:
+    resolution: {integrity: sha512-N2gxk68Kg2qZLSJ4h0NffEhp4BjgWHCHXVlDi1aG1hA3y+ZeWEmHqnpml8Hy47QzfL1xLy5nwr9LcsWAg2Ep0A==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  split-buffer@1.0.0:
+    resolution: {integrity: sha512-cbHOF413jAsBL7JLpU1RWX07Xs+dPb25DbeCvwDzSN3+4bNmRPJa2QHpDdtREgGKgIfx6Tzj/jiqyOS3kNLPnQ==}
+
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
+  ssb-about-self@1.1.0:
+    resolution: {integrity: sha512-AG07Dg2XG9CJvK52qrpwz54cXu+G6sPKwPiOb2LX5K+ORGhA+4MJUVViwuMEcOCI1a1wmXvOKFJbeTaFtosSAw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      ssb-db2: '>=3.4.0'
+
+  ssb-bendy-butt@1.0.2:
+    resolution: {integrity: sha512-PGIfYKLcpyKAGO6AS3BHctjxL58xK/DN6qmDBYVlxxqT+DI+482XYBCNKGtYfnCUlyBK+qO7lmbJp/DQhR8jmQ==}
+
+  ssb-bfe-spec@0.8.0:
+    resolution: {integrity: sha512-0NuyOS0CK1LAoJY+c3d9VmhGFuT1ylFKp+3T7Cttgq7LHhh0zMYZdzeJCUtTYgjsW/grvwRzUuNtYffJSYT0aA==}
+
+  ssb-bfe@1.1.0:
+    resolution: {integrity: sha512-viY/ZzQENnO+gvahYQ35tf3OPV6ChQ+CxnyPpiloDZu7bzQNL0E24wjmoGefF+ftaCK/meeWKP3Hxm7pG50cFA==}
+
+  ssb-bfe@3.7.0:
+    resolution: {integrity: sha512-uJVMPAQhnm8Vz+5H7mP36kGhu0ZIloiDkNrkiO/xGWcr8gMv+GXX2DyNNPD7j0xZmL7HfFqgTvPXFeuni2w4IQ==}
+
   ssb-blobs@2.0.1:
     resolution: {integrity: sha512-WuF96Yc8bd0l62wGxpQNT2OGf2XEhdMLEYsWJeXilYtEJLW+IZoO4YUjPanmp4fkhU2KunN+a/cQr6vqDqLphA==}
+
+  ssb-box2@2.3.0:
+    resolution: {integrity: sha512-oPtupvneFUUb5IItf/Y4Et4ZYL8iU5t3VyH70v7vgrxZeDFmDhwUtsFiRU8+526Av99ztyhEONx/UQOimgGXig==}
+
+  ssb-box2@3.0.1:
+    resolution: {integrity: sha512-jQhrsEyrpqnUciEb1qzqc/SJCAx3hTm48BMzMy1bE//xQthWRahigTffflOM7pdRieGlxwGlHc8PpagBBZOkhA==}
+
+  ssb-box@1.0.1:
+    resolution: {integrity: sha512-/lZOqFr5glmzKTmpXZ8/QbvYA6/mVQ6dDPT/+zsYQkKKEHaloMkMPRRXlK86xG+/Bsuw2HGjcm78W09aWshS+g==}
+    engines: {node: '>=12'}
+
+  ssb-browser-core@14.0.0:
+    resolution: {integrity: sha512-3FCFyDtMdG8Dzles7lXGI7ZQ0C5z6l+UOT1z66EcarD4Ski4A6sJm1nk2XvHAzEFUOm3DyMEklKLacv6eG690A==}
+
+  ssb-buttwoo@0.3.3:
+    resolution: {integrity: sha512-TA4xIs+4abz8Zn40LfrM2qM/hkpn5gYmy76yFGo9KkbDYoiVc5+Wk589yUf1ahcCzfDZN/lltRgBUzyeEY36uw==}
+
+  ssb-caps@1.1.0:
+    resolution: {integrity: sha512-qe3qpvchJ+gnH8M/ge4rpL+7eRbSmsEAzNwHkDdrW06OBcziQ6/KuAdmcR6joxCbNeoAXAZF+inkefgE16okXA==}
+
+  ssb-classic@1.1.0:
+    resolution: {integrity: sha512-aR1nifEXIpyNP+tRmQ8Sw2ra9nhPGrJnhH6xGTmSn4GXSwy5Gm4JCrpzcKvzUKzKMsfmqw5HVug+2/IVkvEVXQ==}
+    engines: {node: '>=12'}
+
+  ssb-conn-db@1.0.5:
+    resolution: {integrity: sha512-2rbqjvlDMTke2/qgauA415QSQ4hUJziXHqcXuC2Yh1uPrCDXHXrp0dhCchn0b/taEeL0Ppqo/Tsy6szQdqlEDw==}
+
+  ssb-conn-hub@1.2.1:
+    resolution: {integrity: sha512-EazMSgPJSOZTp/NdhUOq4kduAliT9k0GNJvao3Muvqk4Y17V4yIwCKt8SENHI5BMz2ATrDmFLj9uf5z/83Txww==}
+
+  ssb-conn-query@1.2.2:
+    resolution: {integrity: sha512-pvCU8oxpX9sBap6oBrLUwDGAYnHSxkhYAYnj6RxGNotPKDIRZUBZB04yQ4nA1rHm7oHOnBgcuK0GRWls78pnkQ==}
+
+  ssb-conn-staging@1.0.0:
+    resolution: {integrity: sha512-NOy1qZoBkhH0XNzLteaaKKePXigEJSCntD4RPRU6vWLMlQ10+SzlIz4TWKgvEVx0LfCe6tEx/vhQf6vBWO/Ylw==}
+
+  ssb-conn@6.0.4:
+    resolution: {integrity: sha512-rCjpBBPKx9fe3mmrPUcdVz3voE490SqE4BWkBkQuEBi9d/WEMnJymPSJklHN5jmW2Yv4cDIMhnvbfOqu3P18ag==}
+    peerDependencies:
+      secret-stack: '>=6.2.0'
+
+  ssb-db2@5.2.0:
+    resolution: {integrity: sha512-1S3BpDqCmPZQqgDGLc+Sppla96u/GE+UxQKq3OAhhfXAW0WY1j1n6+6vCmFtVdIdOmP01rIm5Ocws9eTkFnsEQ==}
+
+  ssb-db2@6.3.3:
+    resolution: {integrity: sha512-H5WztPw1lJmUR1e12McRABT4OStiwygDutirHhx1P520ssu5pTmuKrcUM/uSaEPbEPsLif17HpdKKd1fK2uxYg==}
+
+  ssb-ebt@9.1.2:
+    resolution: {integrity: sha512-nNR26/3da8e+39fARLFDhrNdbkycxvmXqoK7QxrHGJaY/opBGtZ7GaHjNKkaXcF4Fl04ee+NhkYaiq18pGI0RQ==}
+    engines: {node: '>=10'}
+
+  ssb-friends@5.1.7:
+    resolution: {integrity: sha512-oBoMmcw5URa16CXM7LV1YG+YAGdwsQHkHevkh1VVKqhxxi8UAQ1qseb0iQ9Xdzwgadh9lRaW/aGz+175xrcxig==}
+    engines: {node: '>=10'}
+
+  ssb-index-feeds@0.10.2:
+    resolution: {integrity: sha512-j4j24OeD5CMGWcfjlk9ZUiQda6Obx/1z4X/SjYmBJBsX6mjVLJ0Kz0MbO607oVCls7AXdlgBCs6UsCGoO/VJiA==}
+
+  ssb-keyring@2.2.0:
+    resolution: {integrity: sha512-pXNzYsQbtdWoWAjEPT5lVrZs/Px4ypJU2m4S34tTN6KivZukHPcflj1/IbZSDj7kHJGQhJRcyqGQ3MxgQdFBrA==}
+
+  ssb-keys@8.5.0:
+    resolution: {integrity: sha512-Fdgnz5QQ/oK/bMf5Hkaqss/INqiKHFHG4RKDk3StWrQC4fUKMSL/GfnkxFlcLFGhVomzxUmhtAnhJQx2WecEKQ==}
+    engines: {node: '>=5.10.0'}
+
+  ssb-meta-feeds@0.29.0:
+    resolution: {integrity: sha512-YestPkd36y8BI471VZsZisYIZV46T62R3cCABfo+xn1UQh9aN3ykHDTqxwuj14M7G5jK/S0ur7T7Cv8cK+VBFA==}
+
+  ssb-msg-content@1.0.1:
+    resolution: {integrity: sha512-M6W0Ef+jif829USmGvh6XeS4lYb/F2lgFhfEoCE/md7ESILNOGidp8frJE2uVOzSr2wVRA265tPrnVb7rYHkug==}
+
+  ssb-network-errors@1.0.1:
+    resolution: {integrity: sha512-Re6q7yZL4GreJXbfa7QWk24Nr/I7bs3cIszV2usiSqVYyDphkcwT8iOXFyqjWxG9gVA3Lfjj+6uwX2WI7SorPw==}
+
+  ssb-no-auth@1.0.0:
+    resolution: {integrity: sha512-+o9WnY566shLyiJp6l21+SHZfgv40SEr35PtoF3uuFYI24vFhgcfv77pXvWpDINVyX2uQ152o2eQHg1amlp6lQ==}
+
+  ssb-private-group-keys@0.4.1:
+    resolution: {integrity: sha512-Npl9NpUZvHho10h18/tphMfuyMlj+6lLW0mm+u8ooIRgVh5+hyoOtgJL22VmTEyD8KQVJG6SOjiv6MiGXzIL3g==}
+
+  ssb-private-group-keys@1.1.2:
+    resolution: {integrity: sha512-0UPPmxy61qmbDmP71J2vhX6UPfCtXa/CNehxYTgk2+AaLXsnA0perGZAiOWm9niGEU50TYYC5/jsIfjz4IiD9A==}
 
   ssb-ref@2.16.0:
     resolution: {integrity: sha512-ylyrfz9NLxwTCbeDDAdLo++O3elhNs6/gUqMhZ22F+gSOIjwXy2X7dpg5Q1YTH7uALOSu307Rpo1UfK9sj7Sjw==}
 
+  ssb-replication-scheduler@2.0.5:
+    resolution: {integrity: sha512-y5WRdMT7Xx3haPh8dsffOg+0HLgL4d4zltKQK1/ziasoGsVh6RQHnWYw/s09I1OA8oI9wMhY8VJ8xbloLnH+7Q==}
+    engines: {node: '>=10'}
+
+  ssb-room-client@2.0.2:
+    resolution: {integrity: sha512-ThQau7iz+TVvbdhBDo5PWCaKPTHYQNEfvlfFXOlT9yKIUK/x11whPsF2o82qzmJXWW19okQOX/U7Lju9oM2pdw==}
+
+  ssb-sort@1.1.3:
+    resolution: {integrity: sha512-oPsF8lGgcHcIb4F1GddV3CbZTJZ0OzxI9fHXH0Zc7ZjqjFlYdqMDxFSuvqJnmtDydJcswyGANiziP1ghd69jOw==}
+
+  ssb-subset-ql@1.0.1:
+    resolution: {integrity: sha512-msZA4Oc1rgEEAVLyzMiQNxJf85+XBrw7IEQLHQpMDv+o/p4GGX9Ygijc2RtItnWSu1H5fFcZChL8pf/q+j3q+w==}
+
+  ssb-typescript@2.8.0:
+    resolution: {integrity: sha512-akqVsc2HNM0x5q4iN8v/t0jDuNOyU8E8UfyObqU4qWALIXLUptUQd1n03bWOcDn/+sjb2CLpjq584gDoQ4gEjw==}
+
+  ssb-uri2@2.4.1:
+    resolution: {integrity: sha512-3Oia/V8Q7kWj2/Wcw67yKSkMcxQIAIHGDZ4CsQxqVrEjqApYkQ5Drj0nlyFCA/qX8HF0ILFwIrHuQesk0s2PkQ==}
+    engines: {node: '>=10'}
+
+  ssb-validate@4.1.4:
+    resolution: {integrity: sha512-nzj5EQnhm5fBGXgtzuuWgxv45dW+CJJm4eCLZKiOxyG1NE/WJZwju2DmqZfiE9zr9bC2T2hPHkckDP0CCP8v8w==}
+
+  ssb-ws@6.2.3:
+    resolution: {integrity: sha512-zZ/Q1M+9ZWlrchgh4QauD/MEUFa6eC6H6FYq6T8Of/y82JqsQBLwN6YlzbO09evE7Rx6x0oliXDCnQSjwGwQRA==}
+
+  stack@0.1.0:
+    resolution: {integrity: sha512-MCDcCsqemsYpCg/eeR48p6RqA18We4AaXcYmiZyppx27AA58oleDMZpG+ewRA61vG5iUeAGPHinkFQg/REZMfA==}
+    engines: {'0': node >= 0.2.0}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statistics@3.3.0:
+    resolution: {integrity: sha512-9+dmo0XcSK1AU6/uNuSUV/9/KnGUT+7ZKeL+J4IWcjcczflFTWwYQaInBBSo2zyEFVkFd59bGVxzZ8SSBWC66g==}
 
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
+
   stream-to-pull-stream@1.7.3:
     resolution: {integrity: sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==}
+
+  string.prototype.trim@1.2.10:
+    resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimend@1.0.9:
+    resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimstart@1.0.8:
+    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
+    engines: {node: '>= 0.4'}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-literal@3.0.0:
     resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -1222,6 +2214,22 @@ packages:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
+  to-buffer@1.2.1:
+    resolution: {integrity: sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==}
+    engines: {node: '>= 0.4'}
+
+  to-camel-case@1.0.0:
+    resolution: {integrity: sha512-nD8pQi5H34kyu1QDMFjzEIYqk0xa9Alt6ZfrdEMuHCFOfTLhDG5pgTu/aAM9Wt9lXILwlXmWP43b8sav0GNE8Q==}
+
+  to-no-case@1.0.2:
+    resolution: {integrity: sha512-Z3g735FxuZY8rodxV4gH7LxClE4H0hTIyHNIHdk+vpQxjLm0cwnKXq/OFVZ76SOQmto7txVcwSCwkU5kqp+FKg==}
+
+  to-space-case@1.0.0:
+    resolution: {integrity: sha512-rLdvwXZ39VOn1IxGL3V6ZstoTbwLRckQmn/U8ZDLuWwIXNpuZDhQ3AiRUlhTbOXFVE9C+dR51wM0CBDhk31VcA==}
+
+  too-hot@1.0.1:
+    resolution: {integrity: sha512-ymyiJ8bM8e2wKfJpxbq4Fi7GwLy9w7P8PKHnsWlDgbRIampbMtjv8eFrvpMIC0bK5dKybYrYqvbLUVu5/sDQbw==}
+
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
@@ -1230,13 +2238,62 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
+  traverse@0.6.11:
+    resolution: {integrity: sha512-vxXDZg8/+p3gblxB6BhhG5yWVn1kGRlaL8O78UDXc3wRnPizB5g83dcvWV1jpDMIPnjZjOFuxlMmE82XJ4407w==}
+    engines: {node: '>= 0.4'}
+
+  truncate-utf8-bytes@1.0.2:
+    resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tweetnacl-auth@0.3.1:
+    resolution: {integrity: sha512-9/c8c6qRMTfWuv54ETFhihgYoofi0M9HUovMSGJ1rLRUj6O5A0vuCg2L/qKfvmcjLVhaTgAJCLy2EqCLJK2QLw==}
+
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
+
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-length@1.0.3:
+    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-offset@1.0.4:
+    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-length@1.0.7:
+    resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
+    engines: {node: '>= 0.4'}
+
+  typedarray-to-buffer@4.0.0:
+    resolution: {integrity: sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==}
+
+  typedarray.prototype.slice@1.0.5:
+    resolution: {integrity: sha512-q7QNVDGTdl702bVFiI5eY4l/HkgCM6at9KhcFbgUAzezHFbOVy4+0O/lCjsABEQwbZPravVfBIiBVGo89yzHFg==}
+    engines: {node: '>= 0.4'}
+
+  typedfastbitset@0.2.1:
+    resolution: {integrity: sha512-B2B+wo5gC7VRAqcFEiUCjS6CJ1vmeYZ7uzY3Jsu6UNStHiF+W0vkhZAmQaj5m9sC2KVrpyHGRzGuhz3M6+n/8A==}
 
   typescript@5.9.2:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uint48be@2.0.1:
+    resolution: {integrity: sha512-LQvWofTo3RCz+XaQR3VNch+dDFwpIvWr/98imhQne++vFhpQP16YAC/a8w9N00Heqqra00ACjHT18cgvn5H+bg==}
+
+  unbox-primitive@1.1.0:
+    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
+    engines: {node: '>= 0.4'}
 
   undici-types@7.8.0:
     resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
@@ -1260,6 +2317,9 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  utf8-byte-length@1.0.5:
+    resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -1357,6 +2417,22 @@ packages:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
 
+  which-boxed-primitive@1.1.1:
+    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
+    engines: {node: '>= 0.4'}
+
+  which-builtin-type@1.2.1:
+    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
+    engines: {node: '>= 0.4'}
+
+  which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
+
+  which-typed-array@1.1.19:
+    resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
+    engines: {node: '>= 0.4'}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -1364,6 +2440,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@7.5.10:
+    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
@@ -1384,9 +2472,15 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  xsalsa20@1.2.0:
+    resolution: {integrity: sha512-FIr/DEeoHfj7ftfylnoFt3rAIRoWXpx2AoDfrT2qD2wtp7Dp+COajvs/Icb7uHqRW9m60f5iXZwdsJJO3kvb7w==}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
+
+  ziii@1.0.2:
+    resolution: {integrity: sha512-q1FogtBIchy1W0fkxUpe6A4n4WUvAM+hAHN1J6LjBNCV42ZegeC5JSz0mcNv4qxnI0V4cL4FNeEhPMm97Ed0kA==}
 
   zod@4.0.14:
     resolution: {integrity: sha512-nGFJTnJN6cM2v9kXL+SOBq3AtjQby3Mv5ySGFof5UGRHrRioSJ5iG680cYNjE/yWk671nROcpPj4hAS8nyLhSw==}
@@ -1410,6 +2504,8 @@ packages:
         optional: true
 
 snapshots:
+
+  '@alloc/quick-lru@5.2.0': {}
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -1524,6 +2620,16 @@ snapshots:
   '@ffmpeg/types@0.12.4': {}
 
   '@jridgewell/sourcemap-codec@1.5.4': {}
+
+  '@minireq/browser@2.0.0':
+    dependencies:
+      '@minireq/common': 2.0.0
+
+  '@minireq/common@2.0.0': {}
+
+  '@minireq/node@2.0.0':
+    dependencies:
+      '@minireq/common': 2.0.0
 
   '@noble/hashes@1.8.0': {}
 
@@ -1730,6 +2836,11 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.46.2':
     optional: true
 
+  '@sammacbeth/random-access-idb-mutable-file@0.1.1':
+    dependencies:
+      buffer: 5.1.0
+      random-access-storage: 1.3.0
+
   '@types/chai@5.2.2':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -1816,28 +2927,134 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  aligned-block-file@1.2.2:
+    dependencies:
+      hashlru: 2.3.0
+      int53: 1.0.0
+      mkdirp: 0.5.6
+      obv: 0.0.1
+      rwlock: 5.0.0
+      uint48be: 2.0.1
+
+  append-batch@0.0.2: {}
+
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
 
+  array-buffer-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      is-array-buffer: 3.0.5
+
+  arraybuffer.prototype.slice@1.0.4:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      is-array-buffer: 3.0.5
+
   assertion-error@2.0.1: {}
 
+  async-append-only-log@4.3.10:
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      atomic-file-rw: 0.3.0
+      debug: 4.4.1
+      is-buffer-zero: 1.0.0
+      lodash.debounce: 4.0.8
+      looper: 4.0.0
+      ltgt: 2.2.1
+      mutexify: 1.4.0
+      obz: 1.1.1
+      polyraf: 1.1.0
+      push-stream: 11.2.0
+      push-stream-to-pull-stream: 1.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  async-function@1.0.0: {}
+
+  async-single@1.0.5: {}
+
+  atomic-file-rw@0.3.0:
+    dependencies:
+      idb-kv-store: 4.5.0
+      mutexify: 1.4.0
+
+  atomic-file@2.1.1:
+    dependencies:
+      flumecodec: 0.0.1
+      idb-kv-store: 4.5.0
+      mutexify: 1.4.0
+
   attr-accept@2.2.5: {}
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
+  b4a@1.6.7: {}
 
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
 
+  base64-url@2.3.3: {}
+
+  bencode@2.0.3: {}
+
+  binary-search-bounds@2.0.5: {}
+
   bip39@3.1.0:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  bipf@1.9.0:
+    dependencies:
+      fast-varint: 1.0.1
+
+  blake2b-wasm@2.4.0:
+    dependencies:
+      b4a: 1.6.7
+      nanoassert: 2.0.0
+
+  blake2b@2.1.4:
+    dependencies:
+      blake2b-wasm: 2.4.0
+      nanoassert: 2.0.0
+
   blake2s@1.1.0: {}
+
+  blake3@2.1.7: {}
 
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+
+  buffer-alloc-unsafe@1.1.0: {}
+
+  buffer-alloc@1.2.0:
+    dependencies:
+      buffer-alloc-unsafe: 1.1.0
+      buffer-fill: 1.0.0
+
+  buffer-fill@1.0.0: {}
+
+  buffer-from@0.1.2: {}
+
+  buffer-xor@2.0.2:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  buffer@5.1.0:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   buffer@5.7.1:
     dependencies:
@@ -1846,7 +3063,28 @@ snapshots:
 
   cac@6.7.14: {}
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bind@1.0.8:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   canvas-confetti@1.9.3: {}
+
+  chacha20-universal@1.0.4:
+    dependencies:
+      nanoassert: 2.0.0
 
   chai@5.2.1:
     dependencies:
@@ -1856,7 +3094,21 @@ snapshots:
       loupe: 3.2.0
       pathval: 2.0.1
 
+  charwise@3.0.1: {}
+
   check-error@2.1.1: {}
+
+  chloride-test@1.2.4:
+    dependencies:
+      json-buffer: 2.0.11
+
+  chloride@2.4.1:
+    dependencies:
+      sodium-browserify: 1.3.0
+      sodium-browserify-tweetnacl: 0.2.6
+      sodium-chloride: 1.1.2
+    optionalDependencies:
+      sodium-native: 3.4.1
 
   clarify-error@1.0.0: {}
 
@@ -1889,6 +3141,12 @@ snapshots:
 
   continuable@1.2.0: {}
 
+  cpu-percentage@1.0.3: {}
+
+  crc@3.6.0:
+    dependencies:
+      buffer: 5.7.1
+
   cssstyle@4.6.0:
     dependencies:
       '@asamuzakjp/css-color': 3.2.0
@@ -1901,6 +3159,24 @@ snapshots:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
 
+  data-view-buffer@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-offset@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
@@ -1909,14 +3185,56 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
+  deep-equal@1.1.2:
+    dependencies:
+      is-arguments: 1.2.0
+      is-date-object: 1.1.0
+      is-regex: 1.2.1
+      object-is: 1.1.6
+      object-keys: 1.1.1
+      regexp.prototype.flags: 1.5.4
+
   deferred-leveldown@5.3.0:
     dependencies:
       abstract-leveldown: 6.2.3
       inherits: 2.0.4
 
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+
   detect-node-es@1.1.0: {}
 
   discontinuous-range@1.0.0: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  dynamic-dijkstra@1.0.2:
+    dependencies:
+      heap: 0.2.7
+      rng: 0.2.2
+
+  ed2curve@0.1.4:
+    dependencies:
+      tweetnacl: 0.14.5
+
+  emoji-named-characters@1.0.2: {}
+
+  emoji-server@1.0.0:
+    dependencies:
+      emoji-named-characters: 1.0.2
 
   encoding-down@6.3.0:
     dependencies:
@@ -1927,11 +3245,105 @@ snapshots:
 
   entities@6.0.1: {}
 
+  envelope-js@1.3.2:
+    dependencies:
+      buffer-xor: 2.0.2
+      envelope-spec: 1.1.1
+      futoin-hkdf: 1.5.3
+      sodium-universal: 3.1.0
+      ssb-bfe: 3.7.0
+
+  envelope-spec@1.1.1:
+    dependencies:
+      ssb-bfe: 1.1.0
+
+  epidemic-broadcast-trees@9.0.4:
+    dependencies:
+      push-stream: 11.2.0
+
   errno@0.1.8:
     dependencies:
       prr: 1.0.1
 
+  es-abstract@1.24.0:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      arraybuffer.prototype.slice: 1.0.4
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      data-view-buffer: 1.0.2
+      data-view-byte-length: 1.0.2
+      data-view-byte-offset: 1.0.1
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-set-tostringtag: 2.1.0
+      es-to-primitive: 1.3.0
+      function.prototype.name: 1.1.8
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      get-symbol-description: 1.1.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      internal-slot: 1.1.0
+      is-array-buffer: 3.0.5
+      is-callable: 1.2.7
+      is-data-view: 1.0.2
+      is-negative-zero: 2.0.3
+      is-regex: 1.2.1
+      is-set: 2.0.3
+      is-shared-array-buffer: 1.0.4
+      is-string: 1.1.1
+      is-typed-array: 1.1.15
+      is-weakref: 1.1.1
+      math-intrinsics: 1.1.0
+      object-inspect: 1.13.4
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      own-keys: 1.0.1
+      regexp.prototype.flags: 1.5.4
+      safe-array-concat: 1.1.3
+      safe-push-apply: 1.0.0
+      safe-regex-test: 1.1.0
+      set-proto: 1.0.0
+      stop-iteration-iterator: 1.1.0
+      string.prototype.trim: 1.2.10
+      string.prototype.trimend: 1.0.9
+      string.prototype.trimstart: 1.0.8
+      typed-array-buffer: 1.0.3
+      typed-array-byte-length: 1.0.3
+      typed-array-byte-offset: 1.0.4
+      typed-array-length: 1.0.7
+      unbox-primitive: 1.1.0
+      which-typed-array: 1.1.19
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  es-to-primitive@1.3.0:
+    dependencies:
+      is-callable: 1.2.7
+      is-date-object: 1.1.0
+      is-symbol: 1.1.1
 
   esbuild@0.25.8:
     optionalDependencies:
@@ -1966,7 +3378,15 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  events@3.3.0: {}
+
   expect-type@1.2.2: {}
+
+  fast-varint@1.0.1: {}
+
+  fastintcompression@0.0.4: {}
+
+  fastpriorityqueue@0.7.5: {}
 
   fdir@6.4.6(picomatch@4.0.3):
     optionalDependencies:
@@ -1976,12 +3396,94 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  flumecodec@0.0.0:
+    dependencies:
+      level-codec: 6.2.0
+
+  flumecodec@0.0.1:
+    dependencies:
+      level-codec: 6.2.0
+
+  flumelog-offset@3.4.4:
+    dependencies:
+      aligned-block-file: 1.2.2
+      append-batch: 0.0.2
+      hashlru: 2.3.0
+      int53: 1.0.0
+      looper: 4.0.0
+      obv: 0.0.1
+      pull-cursor: 3.0.0
+      pull-looper: 1.0.0
+      pull-stream: 3.7.0
+      uint48be: 2.0.1
+
+  flumeview-reduce@1.4.0:
+    dependencies:
+      async-single: 1.0.5
+      atomic-file: 2.1.1
+      deep-equal: 1.1.2
+      flumecodec: 0.0.0
+      obv: 0.0.1
+      pull-notify: 0.1.2
+      pull-stream: 3.7.0
+
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
+  function.prototype.name@1.1.8:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      functions-have-names: 1.2.3
+      hasown: 2.0.2
+      is-callable: 1.2.7
+
+  functions-have-names@1.2.3: {}
+
+  futoin-hkdf@1.5.3: {}
+
+  generate-function@2.3.1:
+    dependencies:
+      is-property: 1.0.2
+
+  generate-object-property@1.2.0:
+    dependencies:
+      is-property: 1.0.2
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-symbol-description@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
 
   glob@7.2.3:
     dependencies:
@@ -1991,6 +3493,46 @@ snapshots:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
+
+  gopd@1.2.0: {}
+
+  gossip-query@2.0.2:
+    dependencies:
+      obv: 0.0.1
+      pull-stream: 3.7.0
+
+  has-bigints@1.1.0: {}
+
+  has-network2@0.0.3: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-proto@1.2.0:
+    dependencies:
+      dunder-proto: 1.0.1
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hashlru@2.3.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  heap@0.2.7: {}
+
+  hoox@0.0.1: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -2014,9 +3556,16 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  idb-kv-store@4.5.0:
+    dependencies:
+      inherits: 2.0.4
+      promisize: 1.1.2
+
   ieee754@1.2.1: {}
 
   immediate@3.3.0: {}
+
+  increment-buffer@1.0.1: {}
 
   inflight@1.0.6:
     dependencies:
@@ -2025,19 +3574,193 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  int53@1.0.0: {}
+
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.2
+      side-channel: 1.1.0
+
+  ip-address@9.0.5:
+    dependencies:
+      jsbn: 1.1.0
+      sprintf-js: 1.1.3
+
   ip@1.1.9: {}
+
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-array-buffer@3.0.5:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  is-async-function@2.1.1:
+    dependencies:
+      async-function: 1.0.0
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-bigint@1.1.0:
+    dependencies:
+      has-bigints: 1.1.0
+
+  is-boolean-object@1.2.2:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-buffer-zero@1.0.0: {}
+
+  is-callable@1.2.7: {}
 
   is-canonical-base64@1.1.1: {}
 
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
+
+  is-data-view@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      is-typed-array: 1.1.15
+
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-finalizationregistry@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-generator-function@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-map@2.0.3: {}
+
+  is-my-ip-valid@1.0.1: {}
+
+  is-my-json-valid@2.20.6:
+    dependencies:
+      generate-function: 2.3.1
+      generate-object-property: 1.2.0
+      is-my-ip-valid: 1.0.1
+      jsonpointer: 5.0.1
+      xtend: 4.0.2
+
+  is-my-ssb-valid@1.2.2:
+    dependencies:
+      is-my-json-valid: 2.20.6
+      ssb-msg-content: 1.0.1
+
+  is-negative-zero@2.0.3: {}
+
+  is-number-object@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-options@1.0.2:
+    dependencies:
+      b4a: 1.6.7
+
   is-potential-custom-element-name@1.0.1: {}
+
+  is-property@1.0.2: {}
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  is-set@2.0.3: {}
+
+  is-shared-array-buffer@1.0.4:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-string@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-symbol@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-symbols: 1.1.0
+      safe-regex-test: 1.1.0
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.19
 
   is-valid-domain@0.0.20:
     dependencies:
       punycode: 1.4.1
 
+  is-weakmap@2.0.2: {}
+
+  is-weakref@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-weakset@2.0.4:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  isarray@2.0.5: {}
+
+  jitdb@7.0.7(async-append-only-log@4.3.10):
+    dependencies:
+      async-append-only-log: 4.3.10
+      atomic-file-rw: 0.3.0
+      binary-search-bounds: 2.0.5
+      bipf: 1.9.0
+      crc: 3.6.0
+      debug: 4.4.1
+      fastpriorityqueue: 0.7.5
+      idb-kv-store: 4.5.0
+      jsesc: 3.1.0
+      mkdirp: 1.0.4
+      multicb: 1.2.2
+      mutexify: 1.4.0
+      obz: 1.1.1
+      promisify-4loc: 1.0.0
+      pull-async: 1.0.0
+      pull-awaitable: 1.0.0
+      pull-cat: 1.1.11
+      pull-stream: 3.7.0
+      push-stream: 11.2.0
+      push-stream-to-pull-stream: 1.0.5
+      rimraf: 3.0.2
+      sanitize-filename: 1.6.3
+      traverse: 0.6.11
+      typedarray-to-buffer: 4.0.0
+      typedfastbitset: 0.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
+
+  jsbn@1.1.0: {}
 
   jsdom@26.1.0:
     dependencies:
@@ -2065,6 +3788,25 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  jsesc@3.1.0: {}
+
+  json-buffer@2.0.11: {}
+
+  jsonpointer@5.0.1: {}
+
+  key-value-file-store@1.1.1:
+    dependencies:
+      atomic-file-rw: 0.3.0
+
+  layered-graph@1.2.0:
+    dependencies:
+      dynamic-dijkstra: 1.0.2
+      pull-cont: 0.1.1
+      pull-notify: 0.1.2
+      pull-stream: 3.7.0
+
+  level-codec@6.2.0: {}
 
   level-codec@9.0.2:
     dependencies:
@@ -2122,6 +3864,14 @@ snapshots:
       level-supports: 1.0.1
       xtend: 4.0.2
 
+  libsodium-wrappers@0.7.15:
+    dependencies:
+      libsodium: 0.7.15
+
+  libsodium@0.7.15: {}
+
+  lodash.debounce@4.0.8: {}
+
   looper@2.0.0: {}
 
   looper@3.0.0: {}
@@ -2146,15 +3896,36 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.4
 
+  map-merge@1.1.0: {}
+
+  math-intrinsics@1.1.0: {}
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
+
+  mkdirp@0.5.6:
+    dependencies:
+      minimist: 1.2.8
+
   mkdirp@1.0.4: {}
+
+  monotonic-timestamp@0.0.9: {}
 
   moo@0.5.2: {}
 
   ms@2.1.3: {}
+
+  multiblob-http@1.2.1:
+    dependencies:
+      pull-many: 1.0.9
+      pull-stream: 3.7.0
+      range-parser: 1.2.1
+      stream-to-pull-stream: 1.7.3
 
   multiblob@1.13.8:
     dependencies:
@@ -2174,9 +3945,50 @@ snapshots:
       rimraf: 3.0.2
       stream-to-pull-stream: 1.7.3
 
+  multicb@1.2.2: {}
+
   multiserver-address@1.0.1:
     dependencies:
       nearley: 2.20.1
+
+  multiserver-scopes@2.0.0:
+    dependencies:
+      non-private-ip: 2.2.0
+
+  multiserver@3.8.2:
+    dependencies:
+      debug: 4.4.1
+      multicb: 1.2.2
+      multiserver-scopes: 2.0.0
+      pull-stream: 3.7.0
+      pull-websocket: 3.4.2
+      secret-handshake: 1.1.21
+      separator-escape: 0.0.1
+      socks: 2.8.6
+      stream-to-pull-stream: 1.7.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  mutexify@1.4.0:
+    dependencies:
+      queue-tick: 1.0.1
+
+  muxrpc@6.7.3:
+    dependencies:
+      clarify-error: 1.0.0
+      debug: 4.4.1
+      packet-stream: 2.0.6
+      packet-stream-codec: 1.2.0
+      pull-goodbye: 0.0.3
+      pull-stream: 3.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  nano-equal@2.0.2: {}
+
+  nanoassert@2.0.0: {}
 
   nanoid@3.3.11: {}
 
@@ -2189,7 +4001,15 @@ snapshots:
       railroad-diagrams: 1.0.0
       randexp: 0.4.6
 
+  next-tick@1.1.0: {}
+
   node-gyp-build@4.1.1: {}
+
+  node-gyp-build@4.8.4: {}
+
+  non-private-ip@2.2.0:
+    dependencies:
+      ip: 1.1.9
 
   normalize-wheel@1.0.1: {}
 
@@ -2197,17 +4017,58 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-inspect@1.13.4: {}
+
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
+
+  obv@0.0.1: {}
+
   obz@1.1.1: {}
+
+  on-change-network-strict@1.0.0: {}
+
+  on-wakeup@1.0.1: {}
 
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  own-keys@1.0.1:
+    dependencies:
+      get-intrinsic: 1.3.0
+      object-keys: 1.1.1
+      safe-push-apply: 1.0.0
+
+  p-defer@3.0.0: {}
+
+  packet-stream-codec@1.2.0:
+    dependencies:
+      pull-reader: 1.3.1
+      pull-through: 1.0.18
+
+  packet-stream@2.0.6: {}
 
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
 
   path-is-absolute@1.0.1: {}
+
+  path-parse@1.0.7: {}
 
   pathe@2.0.3: {}
 
@@ -2217,11 +4078,32 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  polyraf@1.1.0:
+    dependencies:
+      random-access-file: 2.2.1
+      random-access-web: 2.0.3
+
+  possible-typed-array-names@1.1.0: {}
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  private-box@0.3.1:
+    dependencies:
+      chloride: 2.4.1
+
+  private-group-spec@1.2.0:
+    dependencies:
+      is-my-ssb-valid: 1.2.2
+
+  promisify-4loc@1.0.0: {}
+
+  promisify-tuple@1.2.0: {}
+
+  promisize@1.1.2: {}
 
   prop-types@15.8.1:
     dependencies:
@@ -2231,11 +4113,41 @@ snapshots:
 
   prr@1.0.1: {}
 
+  pull-abortable@4.1.1: {}
+
+  pull-async@1.0.0: {}
+
+  pull-awaitable@1.0.0:
+    dependencies:
+      pull-thenable: 1.0.0
+
+  pull-box-stream@1.0.13:
+    dependencies:
+      chloride: 2.4.1
+      increment-buffer: 1.0.1
+      pull-reader: 1.3.1
+      pull-stream: 3.7.0
+      pull-through: 1.0.18
+      split-buffer: 1.0.0
+
   pull-cat@1.1.11: {}
 
   pull-catch@1.1.0: {}
 
+  pull-cont@0.1.1: {}
+
+  pull-cursor@3.0.0:
+    dependencies:
+      looper: 4.0.0
+      ltgt: 2.2.1
+      pull-stream: 3.7.0
+
   pull-defer@0.2.3: {}
+
+  pull-drain-gently@1.1.0:
+    dependencies:
+      cpu-percentage: 1.0.3
+      pull-pause: 0.0.2
 
   pull-file@0.5.0:
     dependencies:
@@ -2244,6 +4156,8 @@ snapshots:
   pull-file@1.1.0:
     dependencies:
       pull-utf8-decoder: 1.0.2
+
+  pull-flatmap@0.0.1: {}
 
   pull-fs@1.1.6:
     dependencies:
@@ -2255,6 +4169,22 @@ snapshots:
   pull-glob@1.0.7:
     dependencies:
       pull-fs: 1.1.6
+      pull-stream: 3.7.0
+
+  pull-goodbye@0.0.3:
+    dependencies:
+      pull-stream: 3.7.0
+
+  pull-handshake@1.1.4:
+    dependencies:
+      pull-cat: 1.1.11
+      pull-pair: 1.1.0
+      pull-pushable: 2.2.0
+      pull-reader: 1.3.1
+
+  pull-inactivity@2.1.4:
+    dependencies:
+      pull-abortable: 4.1.1
       pull-stream: 3.7.0
 
   pull-level@2.0.4:
@@ -2272,21 +4202,62 @@ snapshots:
       pull-cat: 1.1.11
       pull-stream: 3.7.0
 
+  pull-looper@1.0.0:
+    dependencies:
+      looper: 4.0.0
+
+  pull-many@1.0.9:
+    dependencies:
+      pull-stream: 3.7.0
+
   pull-notify@0.1.2:
     dependencies:
       pull-pushable: 2.2.0
+
+  pull-pair@1.1.0: {}
 
   pull-paramap@1.2.2:
     dependencies:
       looper: 4.0.0
 
+  pull-pause@0.0.2: {}
+
+  pull-ping@2.0.3:
+    dependencies:
+      pull-pushable: 2.2.0
+      pull-stream: 3.7.0
+      statistics: 3.3.0
+
   pull-pushable@2.2.0: {}
 
+  pull-rate@1.0.2:
+    dependencies:
+      pull-stream: 3.7.0
+
+  pull-reader@1.3.1: {}
+
   pull-stream@3.7.0: {}
+
+  pull-thenable@1.0.0:
+    dependencies:
+      quicktask: 1.0.1
+
+  pull-through@1.0.18:
+    dependencies:
+      looper: 3.0.0
 
   pull-traverse@1.0.3: {}
 
   pull-utf8-decoder@1.0.2: {}
+
+  pull-websocket@3.4.2:
+    dependencies:
+      relative-url: 1.0.2
+      typedarray-to-buffer: 4.0.0
+      ws: 7.5.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   pull-window@2.1.4:
     dependencies:
@@ -2298,7 +4269,18 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  push-stream-to-pull-stream@1.0.5:
+    dependencies:
+      pull-looper: 1.0.0
+      push-stream: 11.2.0
+
+  push-stream@11.2.0: {}
+
+  queue-tick@1.0.1: {}
+
   quick-lru@7.0.1: {}
+
+  quicktask@1.0.1: {}
 
   railroad-diagrams@1.0.0: {}
 
@@ -2306,6 +4288,56 @@ snapshots:
     dependencies:
       discontinuous-range: 1.0.0
       ret: 0.1.15
+
+  random-access-chrome-file@1.2.0:
+    dependencies:
+      random-access-storage: 1.4.3
+
+  random-access-file@2.2.1:
+    dependencies:
+      mkdirp-classic: 0.5.3
+      random-access-storage: 1.4.3
+
+  random-access-idb-mutable-file@0.3.0:
+    dependencies:
+      buffer: 5.1.0
+      random-access-storage: 1.3.0
+
+  random-access-idb@1.2.2:
+    dependencies:
+      buffer-alloc: 1.2.0
+      buffer-from: 0.1.2
+      inherits: 2.0.4
+      next-tick: 1.1.0
+      once: 1.4.0
+      random-access-storage: 1.4.3
+
+  random-access-memory@3.1.4:
+    dependencies:
+      inherits: 2.0.4
+      is-options: 1.0.2
+      random-access-storage: 1.4.3
+
+  random-access-storage@1.3.0:
+    dependencies:
+      inherits: 2.0.4
+
+  random-access-storage@1.4.3:
+    dependencies:
+      events: 3.3.0
+      inherits: 2.0.4
+      queue-tick: 1.0.1
+
+  random-access-web@2.0.3:
+    dependencies:
+      '@sammacbeth/random-access-idb-mutable-file': 0.1.1
+      random-access-chrome-file: 1.2.0
+      random-access-idb: 1.2.2
+      random-access-idb-mutable-file: 0.3.0
+      random-access-memory: 3.1.4
+      random-access-storage: 1.4.3
+
+  range-parser@1.2.1: {}
 
   react-dom@19.1.1(react@19.1.1):
     dependencies:
@@ -2363,11 +4395,41 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  reflect.getprototypeof@1.0.10:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      which-builtin-type: 1.2.1
+
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
+
+  relative-url@1.0.2: {}
+
+  resolve@1.22.10:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
   ret@0.1.15: {}
 
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  rng@0.2.2: {}
 
   rollup@4.46.2:
     dependencies:
@@ -2397,9 +4459,34 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
+  rwlock@5.0.0: {}
+
+  safe-array-concat@1.1.3:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      isarray: 2.0.5
+
   safe-buffer@5.2.1: {}
 
+  safe-push-apply@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      isarray: 2.0.5
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
   safer-buffer@2.1.2: {}
+
+  sanitize-filename@1.6.3:
+    dependencies:
+      truncate-utf8-bytes: 1.0.2
 
   saxes@6.0.0:
     dependencies:
@@ -2407,9 +4494,207 @@ snapshots:
 
   scheduler@0.26.0: {}
 
+  secret-handshake@1.1.21:
+    dependencies:
+      chloride: 2.4.1
+      clarify-error: 1.0.0
+      pull-box-stream: 1.0.13
+      pull-handshake: 1.1.4
+      pull-stream: 3.7.0
+
+  secret-stack-decorators@1.1.0: {}
+
+  secret-stack@6.4.2:
+    dependencies:
+      debug: 4.4.1
+      hoox: 0.0.1
+      map-merge: 1.1.0
+      multiserver: 3.8.2
+      muxrpc: 6.7.3
+      pull-inactivity: 2.1.4
+      pull-rate: 1.0.2
+      pull-stream: 3.7.0
+      to-camel-case: 1.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  separator-escape@0.0.1: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+
+  set-proto@1.0.0:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+
+  sha.js@2.4.12:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.1
+
+  sha.js@2.4.5:
+    dependencies:
+      inherits: 2.0.4
+
+  sha256-universal@1.2.1:
+    dependencies:
+      b4a: 1.6.7
+      sha256-wasm: 2.2.2
+
+  sha256-wasm@2.2.2:
+    dependencies:
+      b4a: 1.6.7
+      nanoassert: 2.0.0
+
+  sha512-universal@1.2.1:
+    dependencies:
+      b4a: 1.6.7
+      sha512-wasm: 2.3.4
+
+  sha512-wasm@2.3.4:
+    dependencies:
+      b4a: 1.6.7
+      nanoassert: 2.0.0
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
+  siphash24@1.3.1:
+    dependencies:
+      nanoassert: 2.0.0
+
+  smart-buffer@4.2.0: {}
+
+  socks@2.8.6:
+    dependencies:
+      ip-address: 9.0.5
+      smart-buffer: 4.2.0
+
+  sodium-browserify-tweetnacl@0.2.6:
+    dependencies:
+      chloride-test: 1.2.4
+      ed2curve: 0.1.4
+      sha.js: 2.4.12
+      tweetnacl: 1.0.3
+      tweetnacl-auth: 0.3.1
+
+  sodium-browserify@1.3.0:
+    dependencies:
+      libsodium-wrappers: 0.7.15
+      sha.js: 2.4.5
+      sodium-browserify-tweetnacl: 0.2.6
+      tweetnacl: 0.14.5
+
+  sodium-chloride@1.1.2: {}
+
+  sodium-javascript@0.8.0:
+    dependencies:
+      blake2b: 2.1.4
+      chacha20-universal: 1.0.4
+      nanoassert: 2.0.0
+      sha256-universal: 1.2.1
+      sha512-universal: 1.2.1
+      siphash24: 1.3.1
+      xsalsa20: 1.2.0
+
+  sodium-native@3.4.1:
+    dependencies:
+      node-gyp-build: 4.8.4
+
+  sodium-universal@3.1.0:
+    dependencies:
+      blake2b: 2.1.4
+      chacha20-universal: 1.0.4
+      nanoassert: 2.0.0
+      resolve: 1.22.10
+      sha256-universal: 1.2.1
+      sha512-universal: 1.2.1
+      siphash24: 1.3.1
+      sodium-javascript: 0.8.0
+      sodium-native: 3.4.1
+      xsalsa20: 1.2.0
+
   source-map-js@1.2.1: {}
+
+  split-buffer@1.0.0: {}
+
+  sprintf-js@1.1.3: {}
+
+  ssb-about-self@1.1.0(ssb-db2@6.3.3):
+    dependencies:
+      bipf: 1.9.0
+      clarify-error: 1.0.0
+      pull-async: 1.0.0
+      pull-cat: 1.1.11
+      pull-level: 2.0.4
+      pull-stream: 3.7.0
+      ssb-db2: 6.3.3
+
+  ssb-bendy-butt@1.0.2:
+    dependencies:
+      bencode: 2.0.3
+      ssb-bfe: 3.7.0
+      ssb-keys: 8.5.0
+      ssb-uri2: 2.4.1
+
+  ssb-bfe-spec@0.8.0: {}
+
+  ssb-bfe@1.1.0:
+    dependencies:
+      is-canonical-base64: 1.1.1
+      ssb-ref: 2.16.0
+
+  ssb-bfe@3.7.0:
+    dependencies:
+      is-canonical-base64: 1.1.1
+      ssb-bfe-spec: 0.8.0
+      ssb-ref: 2.16.0
+      ssb-uri2: 2.4.1
 
   ssb-blobs@2.0.1:
     dependencies:
@@ -2422,6 +4707,352 @@ snapshots:
       pull-stream: 3.7.0
       ssb-ref: 2.16.0
 
+  ssb-box2@2.3.0:
+    dependencies:
+      envelope-js: 1.3.2
+      private-group-spec: 1.2.0
+      ssb-bfe: 3.7.0
+      ssb-keyring: 2.2.0
+      ssb-private-group-keys: 0.4.1
+      ssb-ref: 2.16.0
+      ssb-uri2: 2.4.1
+
+  ssb-box2@3.0.1:
+    dependencies:
+      envelope-js: 1.3.2
+      private-group-spec: 1.2.0
+      ssb-bfe: 3.7.0
+      ssb-keyring: 2.2.0
+      ssb-private-group-keys: 0.4.1
+      ssb-ref: 2.16.0
+      ssb-uri2: 2.4.1
+
+  ssb-box@1.0.1:
+    dependencies:
+      chloride: 2.4.1
+      private-box: 0.3.1
+      ssb-ref: 2.16.0
+      ssb-uri2: 2.4.1
+
+  ssb-browser-core@14.0.0:
+    dependencies:
+      atomic-file-rw: 0.3.0
+      gossip-query: 2.0.2
+      polyraf: 1.1.0
+      pull-cont: 0.1.1
+      pull-defer: 0.2.3
+      pull-notify: 0.1.2
+      pull-stream: 3.7.0
+      push-stream: 11.2.0
+      push-stream-to-pull-stream: 1.0.5
+      sanitize-filename: 1.6.3
+      secret-stack: 6.4.2
+      ssb-caps: 1.1.0
+      ssb-conn: 6.0.4(secret-stack@6.4.2)
+      ssb-db2: 6.3.3
+      ssb-ebt: 9.1.2
+      ssb-friends: 5.1.7
+      ssb-keys: 8.5.0
+      ssb-no-auth: 1.0.0
+      ssb-ref: 2.16.0
+      ssb-replication-scheduler: 2.0.5
+      ssb-room-client: 2.0.2
+      ssb-sort: 1.1.3
+      ssb-validate: 4.1.4
+      ssb-ws: 6.2.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  ssb-buttwoo@0.3.3:
+    dependencies:
+      base64-url: 2.3.3
+      bipf: 1.9.0
+      blake3: 2.1.7
+      fast-varint: 1.0.1
+      monotonic-timestamp: 0.0.9
+      ssb-bfe: 3.7.0
+      ssb-keys: 8.5.0
+      ssb-uri2: 2.4.1
+
+  ssb-caps@1.1.0: {}
+
+  ssb-classic@1.1.0:
+    dependencies:
+      bipf: 1.9.0
+      is-canonical-base64: 1.1.1
+      ssb-keys: 8.5.0
+      ssb-ref: 2.16.0
+
+  ssb-conn-db@1.0.5:
+    dependencies:
+      atomic-file-rw: 0.3.0
+      debug: 4.4.1
+      multiserver-address: 1.0.1
+      pull-notify: 0.1.2
+      ssb-ref: 2.16.0
+    transitivePeerDependencies:
+      - supports-color
+
+  ssb-conn-hub@1.2.1:
+    dependencies:
+      debug: 4.4.1
+      ip: 1.1.9
+      multiserver: 3.8.2
+      multiserver-address: 1.0.1
+      promisify-tuple: 1.2.0
+      pull-cat: 1.1.11
+      pull-notify: 0.1.2
+      pull-stream: 3.7.0
+      ssb-ref: 2.16.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  ssb-conn-query@1.2.2:
+    dependencies:
+      ssb-conn-db: 1.0.5
+      ssb-conn-hub: 1.2.1
+      ssb-conn-staging: 1.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  ssb-conn-staging@1.0.0:
+    dependencies:
+      debug: 4.4.1
+      multiserver-address: 1.0.1
+      pull-cat: 1.1.11
+      pull-notify: 0.1.2
+      pull-stream: 3.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  ssb-conn@6.0.4(secret-stack@6.4.2):
+    dependencies:
+      debug: 4.4.1
+      has-network2: 0.0.3
+      ip: 1.1.9
+      on-change-network-strict: 1.0.0
+      on-wakeup: 1.0.1
+      pull-notify: 0.1.2
+      pull-pause: 0.0.2
+      pull-ping: 2.0.3
+      pull-stream: 3.7.0
+      secret-stack: 6.4.2
+      secret-stack-decorators: 1.1.0
+      ssb-conn-db: 1.0.5
+      ssb-conn-hub: 1.2.1
+      ssb-conn-query: 1.2.2
+      ssb-conn-staging: 1.0.0
+      ssb-ref: 2.16.0
+      ssb-typescript: 2.8.0
+      statistics: 3.3.0
+      ziii: 1.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  ssb-db2@5.2.0:
+    dependencies:
+      async-append-only-log: 4.3.10
+      atomic-file-rw: 0.3.0
+      binary-search-bounds: 2.0.5
+      bipf: 1.9.0
+      clarify-error: 1.0.0
+      debug: 4.4.1
+      fastintcompression: 0.0.4
+      flumecodec: 0.0.1
+      flumelog-offset: 3.4.4
+      hoox: 0.0.1
+      jitdb: 7.0.7(async-append-only-log@4.3.10)
+      level: 6.0.1
+      level-codec: 9.0.2
+      lodash.debounce: 4.0.8
+      mkdirp: 1.0.4
+      multicb: 1.2.2
+      mutexify: 1.4.0
+      obz: 1.1.1
+      p-defer: 3.0.0
+      pull-cat: 1.1.11
+      pull-drain-gently: 1.1.0
+      pull-level: 2.0.4
+      pull-notify: 0.1.2
+      pull-paramap: 1.2.2
+      pull-stream: 3.7.0
+      push-stream: 11.2.0
+      rimraf: 3.0.2
+      ssb-box: 1.0.1
+      ssb-box2: 2.3.0
+      ssb-classic: 1.1.0
+      ssb-keys: 8.5.0
+      ssb-ref: 2.16.0
+      ssb-uri2: 2.4.1
+      too-hot: 1.0.1
+      typedarray-to-buffer: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  ssb-db2@6.3.3:
+    dependencies:
+      async-append-only-log: 4.3.10
+      atomic-file-rw: 0.3.0
+      binary-search-bounds: 2.0.5
+      bipf: 1.9.0
+      clarify-error: 1.0.0
+      debug: 4.4.1
+      fastintcompression: 0.0.4
+      flumecodec: 0.0.1
+      flumelog-offset: 3.4.4
+      hoox: 0.0.1
+      jitdb: 7.0.7(async-append-only-log@4.3.10)
+      level: 6.0.1
+      level-codec: 9.0.2
+      lodash.debounce: 4.0.8
+      mkdirp: 1.0.4
+      multicb: 1.2.2
+      mutexify: 1.4.0
+      obz: 1.1.1
+      p-defer: 3.0.0
+      pull-cat: 1.1.11
+      pull-drain-gently: 1.1.0
+      pull-level: 2.0.4
+      pull-notify: 0.1.2
+      pull-paramap: 1.2.2
+      pull-stream: 3.7.0
+      push-stream: 11.2.0
+      rimraf: 3.0.2
+      ssb-about-self: 1.1.0(ssb-db2@6.3.3)
+      ssb-box: 1.0.1
+      ssb-box2: 3.0.1
+      ssb-classic: 1.1.0
+      ssb-keys: 8.5.0
+      ssb-ref: 2.16.0
+      ssb-uri2: 2.4.1
+      too-hot: 1.0.1
+      typedarray-to-buffer: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  ssb-ebt@9.1.2:
+    dependencies:
+      base64-url: 2.3.3
+      epidemic-broadcast-trees: 9.0.4
+      key-value-file-store: 1.1.1
+      pull-defer: 0.2.3
+      pull-stream: 3.7.0
+      push-stream-to-pull-stream: 1.0.5
+      ssb-bendy-butt: 1.0.2
+      ssb-buttwoo: 0.3.3
+      ssb-classic: 1.1.0
+      ssb-index-feeds: 0.10.2
+      ssb-network-errors: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  ssb-friends@5.1.7:
+    dependencies:
+      bipf: 1.9.0
+      flumecodec: 0.0.1
+      flumeview-reduce: 1.4.0
+      layered-graph: 1.2.0
+      pull-cont: 0.1.1
+      pull-flatmap: 0.0.1
+      pull-level: 2.0.4
+      pull-notify: 0.1.2
+      pull-pushable: 2.2.0
+      pull-stream: 3.7.0
+      ssb-db2: 6.3.3
+      ssb-ref: 2.16.0
+    transitivePeerDependencies:
+      - supports-color
+
+  ssb-index-feeds@0.10.2:
+    dependencies:
+      debug: 4.4.1
+      is-canonical-base64: 1.1.1
+      pull-cat: 1.1.11
+      pull-stream: 3.7.0
+      ssb-classic: 1.1.0
+      ssb-db2: 6.3.3
+      ssb-keys: 8.5.0
+      ssb-ref: 2.16.0
+      ssb-subset-ql: 1.0.1
+      ssb-uri2: 2.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  ssb-keyring@2.2.0:
+    dependencies:
+      charwise: 3.0.1
+      level: 6.0.1
+      mkdirp: 1.0.4
+      private-group-spec: 1.2.0
+      pull-level: 2.0.4
+      pull-stream: 3.7.0
+      ssb-private-group-keys: 1.1.2
+      ssb-ref: 2.16.0
+      ssb-uri2: 2.4.1
+
+  ssb-keys@8.5.0:
+    dependencies:
+      chloride: 2.4.1
+      mkdirp: 0.5.6
+      private-box: 0.3.1
+      ssb-uri2: 2.4.1
+
+  ssb-meta-feeds@0.29.0:
+    dependencies:
+      bencode: 2.0.3
+      bipf: 1.9.0
+      debug: 4.4.1
+      futoin-hkdf: 1.5.3
+      is-canonical-base64: 1.1.1
+      p-defer: 3.0.0
+      promisify-tuple: 1.2.0
+      pull-cat: 1.1.11
+      pull-notify: 0.1.2
+      pull-stream: 3.7.0
+      ssb-bfe: 3.7.0
+      ssb-db2: 5.2.0
+      ssb-keys: 8.5.0
+      ssb-ref: 2.16.0
+      ssb-uri2: 2.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  ssb-msg-content@1.0.1: {}
+
+  ssb-network-errors@1.0.1: {}
+
+  ssb-no-auth@1.0.0:
+    dependencies:
+      multiserver: 3.8.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  ssb-private-group-keys@0.4.1:
+    dependencies:
+      envelope-js: 1.3.2
+      futoin-hkdf: 1.5.3
+      private-group-spec: 1.2.0
+      sodium-universal: 3.1.0
+      ssb-bfe: 3.7.0
+
+  ssb-private-group-keys@1.1.2:
+    dependencies:
+      envelope-js: 1.3.2
+      futoin-hkdf: 1.5.3
+      private-group-spec: 1.2.0
+      sodium-universal: 3.1.0
+      ssb-bfe: 3.7.0
+
   ssb-ref@2.16.0:
     dependencies:
       ip: 1.1.9
@@ -2429,14 +5060,119 @@ snapshots:
       is-valid-domain: 0.0.20
       multiserver-address: 1.0.1
 
+  ssb-replication-scheduler@2.0.5:
+    dependencies:
+      debug: 4.4.1
+      pull-pushable: 2.2.0
+      pull-stream: 3.7.0
+      ssb-db2: 6.3.3
+      ssb-ebt: 9.1.2
+      ssb-meta-feeds: 0.29.0
+      ssb-network-errors: 1.0.1
+      ssb-subset-ql: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  ssb-room-client@2.0.2:
+    dependencies:
+      '@minireq/browser': 2.0.0
+      '@minireq/node': 2.0.0
+      debug: 4.4.1
+      promisify-tuple: 1.2.0
+      pull-notify: 0.1.2
+      pull-pair: 1.1.0
+      pull-stream: 3.7.0
+      ssb-conn-db: 1.0.5
+      ssb-conn-hub: 1.2.1
+      ssb-conn-staging: 1.0.0
+      ssb-keys: 8.5.0
+      ssb-network-errors: 1.0.1
+      ssb-ref: 2.16.0
+      ssb-typescript: 2.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  ssb-sort@1.1.3:
+    dependencies:
+      ssb-ref: 2.16.0
+
+  ssb-subset-ql@1.0.1:
+    dependencies:
+      nano-equal: 2.0.2
+      ssb-db2: 6.3.3
+      ssb-ref: 2.16.0
+    transitivePeerDependencies:
+      - supports-color
+
+  ssb-typescript@2.8.0: {}
+
+  ssb-uri2@2.4.1:
+    dependencies:
+      ssb-typescript: 2.8.0
+
+  ssb-validate@4.1.4:
+    dependencies:
+      is-canonical-base64: 1.1.1
+      monotonic-timestamp: 0.0.9
+      ssb-keys: 8.5.0
+      ssb-ref: 2.16.0
+
+  ssb-ws@6.2.3:
+    dependencies:
+      emoji-server: 1.0.0
+      multiblob-http: 1.2.1
+      multiserver: 3.8.2
+      pull-box-stream: 1.0.13
+      pull-stream: 3.7.0
+      ssb-ref: 2.16.0
+      stack: 0.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  stack@0.1.0: {}
+
   stackback@0.0.2: {}
 
+  statistics@3.3.0: {}
+
   std-env@3.9.0: {}
+
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
 
   stream-to-pull-stream@1.7.3:
     dependencies:
       looper: 3.0.0
       pull-stream: 3.7.0
+
+  string.prototype.trim@1.2.10:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-data-property: 1.1.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+      es-object-atoms: 1.1.1
+      has-property-descriptors: 1.0.2
+
+  string.prototype.trimend@1.0.9:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  string.prototype.trimstart@1.0.8:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
 
   string_decoder@1.3.0:
     dependencies:
@@ -2445,6 +5181,8 @@ snapshots:
   strip-literal@3.0.0:
     dependencies:
       js-tokens: 9.0.1
+
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
 
@@ -2469,6 +5207,26 @@ snapshots:
     dependencies:
       tldts-core: 6.1.86
 
+  to-buffer@1.2.1:
+    dependencies:
+      isarray: 2.0.5
+      safe-buffer: 5.2.1
+      typed-array-buffer: 1.0.3
+
+  to-camel-case@1.0.0:
+    dependencies:
+      to-space-case: 1.0.0
+
+  to-no-case@1.0.2: {}
+
+  to-space-case@1.0.0:
+    dependencies:
+      to-no-case: 1.0.2
+
+  too-hot@1.0.1:
+    dependencies:
+      cpu-percentage: 1.0.3
+
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
@@ -2477,9 +5235,84 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  traverse@0.6.11:
+    dependencies:
+      gopd: 1.2.0
+      typedarray.prototype.slice: 1.0.5
+      which-typed-array: 1.1.19
+
+  truncate-utf8-bytes@1.0.2:
+    dependencies:
+      utf8-byte-length: 1.0.5
+
   tslib@2.8.1: {}
 
+  tweetnacl-auth@0.3.1:
+    dependencies:
+      tweetnacl: 0.14.5
+
+  tweetnacl@0.14.5: {}
+
+  tweetnacl@1.0.3: {}
+
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-length@1.0.3:
+    dependencies:
+      call-bind: 1.0.8
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-offset@1.0.4:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+      reflect.getprototypeof: 1.0.10
+
+  typed-array-length@1.0.7:
+    dependencies:
+      call-bind: 1.0.8
+      for-each: 0.3.5
+      gopd: 1.2.0
+      is-typed-array: 1.1.15
+      possible-typed-array-names: 1.1.0
+      reflect.getprototypeof: 1.0.10
+
+  typedarray-to-buffer@4.0.0: {}
+
+  typedarray.prototype.slice@1.0.5:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      math-intrinsics: 1.1.0
+      typed-array-buffer: 1.0.3
+      typed-array-byte-offset: 1.0.4
+
+  typedfastbitset@0.2.1: {}
+
   typescript@5.9.2: {}
+
+  uint48be@2.0.1: {}
+
+  unbox-primitive@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-bigints: 1.1.0
+      has-symbols: 1.1.0
+      which-boxed-primitive: 1.1.1
 
   undici-types@7.8.0: {}
 
@@ -2497,6 +5330,8 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.9
+
+  utf8-byte-length@1.0.5: {}
 
   util-deprecate@1.0.2: {}
 
@@ -2592,6 +5427,47 @@ snapshots:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
 
+  which-boxed-primitive@1.1.1:
+    dependencies:
+      is-bigint: 1.1.0
+      is-boolean-object: 1.2.2
+      is-number-object: 1.1.1
+      is-string: 1.1.1
+      is-symbol: 1.1.1
+
+  which-builtin-type@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      function.prototype.name: 1.1.8
+      has-tostringtag: 1.0.2
+      is-async-function: 2.1.1
+      is-date-object: 1.1.0
+      is-finalizationregistry: 1.1.1
+      is-generator-function: 1.1.0
+      is-regex: 1.2.1
+      is-weakref: 1.1.1
+      isarray: 2.0.5
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.19
+
+  which-collection@1.0.2:
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.4
+
+  which-typed-array@1.1.19:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -2599,13 +5475,19 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  ws@7.5.10: {}
+
   ws@8.18.3: {}
 
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
 
+  xsalsa20@1.2.0: {}
+
   xtend@4.0.2: {}
+
+  ziii@1.0.2: {}
 
   zod@4.0.14: {}
 


### PR DESCRIPTION
## Summary
- replace stub SSB instance with ssb-browser-core + blobs and room connection
- publish and query posts, reports and blocks via shared SSB log
- add tests for log replication, reporting and blocking

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e8ab59d4c83319537d7b6545dd52b