### PR TITLE
Implement Cashu mint and zapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "GPL-3.0-or-later",
   "type": "module",
   "dependencies": {
+    "@cashu/cashu-ts": "^2.5.3",
     "@ffmpeg/ffmpeg": "^0.12.0",
     "@radix-ui/react-dialog": "^1.1.14",
     "@yaireo/tagify": "^4.35.3",

--- a/packages/worker-cashu/index.ts
+++ b/packages/worker-cashu/index.ts
@@ -1,17 +1,49 @@
 import { createRPCHandler } from '../../shared/rpc';
-import { generateMnemonic } from 'bip39';
+import { generateMnemonic, mnemonicToSeedSync } from 'bip39';
+import {
+  CashuMint,
+  CashuWallet,
+  MintQuoteState,
+  getEncodedTokenV4,
+  Proof,
+} from '@cashu/cashu-ts';
+
+const MINT_URL = (self as any).CASHU_MINT_URL || 'http://localhost:3333';
+
+let wallet: CashuWallet | null = null;
+let proofs: Proof[] = (globalThis as any).__cashuProofs || [];
+(globalThis as any).__cashuProofs = proofs;
 
 createRPCHandler(self as any, {
-  mint: async (sats) => {
-    // TODO: mint sats using Cashu
-    return sats;
+  mint: async (sats: number) => {
+    if (!wallet) throw new Error('wallet not initialized');
+    const quote = await wallet.createMintQuote(sats);
+    const status = await wallet.checkMintQuote(quote.quote);
+    if (status.state !== MintQuoteState.PAID) {
+      throw new Error('invoice not paid');
+    }
+    const newProofs = await wallet.mintProofs(sats, quote.quote);
+    proofs.push(...newProofs);
+    (globalThis as any).__cashuProofs = proofs;
+    return newProofs.reduce((sum, p) => sum + p.amount, 0);
   },
-  sendZap: async (receiverPk, sats, refId) => {
-    // TODO: send zap
-    return { receiverPk, sats, refId };
+  sendZap: async (receiverPk: string, sats: number, refId: string) => {
+    if (!wallet) throw new Error('wallet not initialized');
+    const { send, keep } = await wallet.send(sats, proofs);
+    proofs = keep;
+    (globalThis as any).__cashuProofs = proofs;
+    const token = getEncodedTokenV4({ mint: MINT_URL, proofs: send });
+    return { receiverPk, sats, refId, token };
   },
   initWallet: async (mnemonic?: string) => {
     const phrase = mnemonic ?? generateMnemonic();
+    const seed = mnemonicToSeedSync(phrase);
+    const mint = new CashuMint(MINT_URL);
+    wallet = new CashuWallet(mint, { bip39seed: seed });
+    await wallet.loadMint();
+    proofs = [];
+    (globalThis as any).__cashuProofs = proofs;
     return phrase;
   },
 });
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@cashu/cashu-ts':
+        specifier: ^2.5.3
+        version: 2.5.3
       '@ffmpeg/ffmpeg':
         specifier: ^0.12.0
         version: 0.12.15
@@ -81,6 +84,9 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@cashu/cashu-ts@2.5.3':
+    resolution: {integrity: sha512-c9xGhWB1XI8xtKZjwDmv50PmmDPXtsFqjEEE+FNqJUGNyRkTIyu5A7a4qOogPGBUveXuFg+YEi2xINH6LJWgdA==}
 
   '@csstools/color-helpers@5.0.2':
     resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
@@ -285,6 +291,10 @@ packages:
 
   '@minireq/node@2.0.0':
     resolution: {integrity: sha512-qaXdz7sQb45Q8r2MGUadP1Wj8cjQ+srG0FhXGiv+5HoD1Mdl3hEqRy1OFjgiAY8KCgt4tIV8W5heYZ6H94A42w==}
+
+  '@noble/curves@1.9.6':
+    resolution: {integrity: sha512-GIKz/j99FRthB8icyJQA51E8Uk5hXmdyThjgQXRKiv9h0zeRlzSCLIzFw6K1LotZ3XuB7yzlf76qk7uBmTdFqA==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -564,6 +574,12 @@ packages:
   '@sammacbeth/random-access-idb-mutable-file@0.1.1':
     resolution: {integrity: sha512-jHnpuu2qtFgwCmhgrpCCk3/hU3XqXTqhidh4XmcTijkVsGwh1c2T0+r2hkHs1PRfsxeimx8qDAotphpRoYB2eg==}
 
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
@@ -741,6 +757,9 @@ packages:
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -2515,6 +2534,13 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
+  '@cashu/cashu-ts@2.5.3':
+    dependencies:
+      '@noble/curves': 1.9.6
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      buffer: 6.0.3
+
   '@csstools/color-helpers@5.0.2': {}
 
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
@@ -2630,6 +2656,10 @@ snapshots:
   '@minireq/node@2.0.0':
     dependencies:
       '@minireq/common': 2.0.0
+
+  '@noble/curves@1.9.6':
+    dependencies:
+      '@noble/hashes': 1.8.0
 
   '@noble/hashes@1.8.0': {}
 
@@ -2840,6 +2870,14 @@ snapshots:
     dependencies:
       buffer: 5.1.0
       random-access-storage: 1.3.0
+
+  '@scure/base@1.2.6': {}
+
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.6
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
 
   '@types/chai@5.2.2':
     dependencies:
@@ -3057,6 +3095,11 @@ snapshots:
       ieee754: 1.2.1
 
   buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1

--- a/shared/ui/ZapButton.test.tsx
+++ b/shared/ui/ZapButton.test.tsx
@@ -11,20 +11,20 @@ describe('ZapButton', () => {
 
   it('disables amounts above balance', () => {
     useBalanceStore.setState({ balance: 50, txs: [] });
-    const html = renderToStaticMarkup(<ZapButton />);
+    const html = renderToStaticMarkup(<ZapButton receiverPk="pk" />);
     const disabledCount = (html.match(/disabled=""/g) || []).length;
     expect(disabledCount).toBe(2);
   });
 
   it('enables all amounts when balance high enough', () => {
     useBalanceStore.setState({ balance: 2000, txs: [] });
-    const html = renderToStaticMarkup(<ZapButton />);
+    const html = renderToStaticMarkup(<ZapButton receiverPk="pk" />);
     expect(html).not.toContain('disabled=""');
   });
 
   it('disables all amounts when disabled prop set', () => {
     useBalanceStore.setState({ balance: 2000, txs: [] });
-    const html = renderToStaticMarkup(<ZapButton disabled />);
+    const html = renderToStaticMarkup(<ZapButton receiverPk="pk" disabled />);
     const disabledCount = (html.match(/disabled=""/g) || []).length;
     expect(disabledCount).toBe(3);
   });

--- a/shared/ui/ZapButton.tsx
+++ b/shared/ui/ZapButton.tsx
@@ -2,6 +2,8 @@ import React, { useRef } from 'react';
 import { useBalanceStore } from './balanceStore';
 
 export interface ZapButtonProps {
+  receiverPk: string;
+  refId?: string;
   onZap?: (amount: number) => void;
   /** Disable all zap options */
   disabled?: boolean;
@@ -11,9 +13,11 @@ const amounts = [21, 100, 1000];
 
 const ZapOption: React.FC<{
   amount: number;
+  receiverPk: string;
+  refId?: string;
   onZap?: (amt: number) => void;
   disabled?: boolean;
-}> = ({ amount, onZap, disabled }) => {
+}> = ({ amount, receiverPk, refId, onZap, disabled }) => {
   const balance =
     typeof window === 'undefined'
       ? useBalanceStore.getState().balance
@@ -27,7 +31,7 @@ const ZapOption: React.FC<{
     const input = window.prompt('Custom zap amount (sats)');
     const value = Number(input);
     if (!isNaN(value) && value > 0 && value <= balance) {
-      zap(value);
+      void zap(receiverPk, value, refId);
       onZap?.(value);
     }
   };
@@ -44,7 +48,7 @@ const ZapOption: React.FC<{
     if (timer.current) clearTimeout(timer.current);
     if (!longPress.current) {
       if (balance >= amount) {
-        zap(amount);
+        void zap(receiverPk, amount, refId);
         onZap?.(amount);
       }
     }
@@ -67,10 +71,23 @@ const ZapOption: React.FC<{
   );
 };
 
-export const ZapButton: React.FC<ZapButtonProps> = ({ onZap, disabled }) => (
+export const ZapButton: React.FC<ZapButtonProps> = ({
+  receiverPk,
+  refId,
+  onZap,
+  disabled,
+}) => (
   <div className="flex gap-2">
     {amounts.map((amt) => (
-      <ZapOption key={amt} amount={amt} onZap={onZap} disabled={disabled} />
+      <ZapOption
+        key={amt}
+        amount={amt}
+        receiverPk={receiverPk}
+        refId={refId}
+        onZap={onZap}
+        disabled={disabled}
+      />
     ))}
   </div>
 );
+

--- a/shared/ui/balanceStore.test.ts
+++ b/shared/ui/balanceStore.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useBalanceStore, setCashuCall } from './balanceStore';
+
+describe('balanceStore', () => {
+  beforeEach(() => {
+    useBalanceStore.setState({ balance: 0, txs: [] });
+  });
+
+  it('updates balance on successful mint', async () => {
+    setCashuCall(((method: any, amount: number) => {
+      if (method === 'mint') return Promise.resolve(amount);
+      return Promise.resolve(null);
+    }) as any);
+    await useBalanceStore.getState().mint(100);
+    const state = useBalanceStore.getState();
+    expect(state.balance).toBe(100);
+    expect(state.txs[0]).toMatchObject({ type: 'mint', status: 'success', amount: 100 });
+  });
+
+  it('records mint failures with error message', async () => {
+    setCashuCall((async () => {
+      throw new Error('mint failed');
+    }) as any);
+    await expect(useBalanceStore.getState().mint(50)).rejects.toThrow('mint failed');
+    const state = useBalanceStore.getState();
+    expect(state.balance).toBe(0);
+    expect(state.txs[0]).toMatchObject({ type: 'mint', status: 'failed', error: 'mint failed' });
+  });
+
+  it('handles successful zap and balance decrease', async () => {
+    setCashuCall((async () => null) as any);
+    useBalanceStore.setState({ balance: 200, txs: [] });
+    await useBalanceStore.getState().zap('pk', 80, 'ref');
+    const state = useBalanceStore.getState();
+    expect(state.balance).toBe(120);
+    expect(state.txs[0]).toMatchObject({ type: 'zap', status: 'success', amount: 80 });
+  });
+});


### PR DESCRIPTION
## Summary
- support real Cashu mint and zap operations in worker
- route balance store mint/zap via RPC with error surfacing
- pass SSB pubkeys through ZapButton and cover balance store with tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688e90e02f8083319b857861ebf30591