### PR TITLE
feat: use web crypto for profile secrets

### DIFF
--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -103,9 +103,9 @@ function OnboardingContent() {
 
   const [toast, setToast] = useState(false);
 
-  const confirm = () => {
+  const confirm = async () => {
     if (mode === 'new' && keys && mnemonic) {
-      const p = createProfile({
+      const p = await createProfile({
         ssbPk: keys.pk,
         ssbSk: keys.sk,
         cashuMnemonic: mnemonic,

--- a/shared/types/profile.test.ts
+++ b/shared/types/profile.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { createProfile, decryptProfileSecrets } from './profile';
+
+describe('profile encryption', () => {
+  it('encrypts and decrypts secrets', async () => {
+    const profile = await createProfile({
+      ssbPk: 'pk',
+      ssbSk: 'secret-sk',
+      cashuMnemonic: 'secret-mnemonic',
+      username: 'alice',
+    });
+
+    expect(profile.ssbSk).not.toBe('secret-sk');
+    expect(profile.cashuMnemonic).not.toBe('secret-mnemonic');
+
+    const secrets = await decryptProfileSecrets(profile);
+    expect(secrets.ssbSk).toBe('secret-sk');
+    expect(secrets.cashuMnemonic).toBe('secret-mnemonic');
+  });
+});


### PR DESCRIPTION
## Summary
- replace Node crypto with Web Crypto API for profile secret encryption/decryption
- update onboarding to await new async profile creation
- add tests for browser-compatible profile encryption

## Testing
- `npm test` *(fails: OpenError: IO error: lock cashucast-ssb/...)*

------
https://chatgpt.com/codex/tasks/task_e_688e93e196308331b5d8763834f8c5e6