### PR TITLE
feat: add DHT toggle

### DIFF
--- a/apps/web/src/routes/SettingsNetwork.tsx
+++ b/apps/web/src/routes/SettingsNetwork.tsx
@@ -2,8 +2,15 @@ import { useState } from 'react';
 import { useSettings } from '../../shared/store/settings';
 
 export default function SettingsNetwork() {
-  const { roomUrl, trackerUrls, setRoomUrl, addTracker, removeTracker } =
-    useSettings();
+  const {
+    roomUrl,
+    trackerUrls,
+    setRoomUrl,
+    addTracker,
+    removeTracker,
+    enableDht,
+    toggleDht,
+  } = useSettings();
   const [newTracker, setNewTracker] = useState('');
 
   return (
@@ -53,6 +60,11 @@ export default function SettingsNetwork() {
           </button>
         </div>
       </div>
+
+      <label className="mt-6 flex items-center gap-2">
+        <input type="checkbox" checked={enableDht} onChange={toggleDht} />
+        <span>Enable DHT bridge (better seeding)</span>
+      </label>
     </div>
   );
 }

--- a/shared/store/settings.ts
+++ b/shared/store/settings.ts
@@ -5,10 +5,12 @@ import { getDefaultEndpoints } from '../config';
 interface SettingsState {
   showNSFW: boolean;
   maxBlobMB: number;
+  enableDht: boolean;
   roomUrl: string;
   trackerUrls: string[];
   setShowNSFW: (v: boolean) => void;
   setMaxBlobMB: (mb: number) => void;
+  toggleDht: () => void;
   setRoomUrl: (u: string) => void;
   addTracker: (u: string) => void;
   removeTracker: (u: string) => void;
@@ -21,6 +23,7 @@ export const useSettings = create<SettingsState>()(
       return {
         showNSFW: false,
         maxBlobMB: 512,
+        enableDht: true,
         roomUrl: room,
         trackerUrls: trackerList,
         setShowNSFW: (v) => set({ showNSFW: v }),
@@ -32,7 +35,10 @@ export const useSettings = create<SettingsState>()(
         },
         setMaxBlobMB(mb: number) {
           set({ maxBlobMB: mb });
-        }
+        },
+        toggleDht() {
+          set({ enableDht: !get().enableDht });
+        },
       };
     },
     { name: 'cashucast-settings' },


### PR DESCRIPTION
## Summary
- allow enabling/disabling DHT bridge via new setting
- add checkbox in network settings UI

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688e9fa18b1083319f0de7cbc0d3f15d