### PR TITLE
feat: add TikTok palette and motion defaults

### DIFF
--- a/shared/styles/global.css
+++ b/shared/styles/global.css
@@ -1,0 +1,3 @@
+#timeline {
+  scroll-snap-type: y mandatory;
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,34 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './apps/**/*.{ts,tsx,js,jsx}',
+    './packages/**/*.{ts,tsx,js,jsx}',
+    './shared/**/*.{ts,tsx,js,jsx}',
+  ],
+  theme: {
+    fontFamily: {
+      sans: ['Inter', 'sans-serif'],
+    },
+    extend: {
+      colors: {
+        primary: '#FF0759',
+        surface: '#121212',
+        subtleBg: '#1F1F1F',
+      },
+      keyframes: {
+        fadeUp: {
+          from: { opacity: '0', transform: 'translateY(0.5rem)' },
+          to: { opacity: '1', transform: 'translateY(0)' },
+        },
+        slideLeft: {
+          from: { transform: 'translateX(100%)' },
+          to: { transform: 'translateX(0)' },
+        },
+      },
+      transitionTimingFunction: {
+        ez: 'cubic-bezier(0.25,0.1,0.25,1)',
+      },
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add Tailwind palette with TikTok colors and motion settings
- enable scroll snapping on timeline

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688ea063fcb48331a2bcd01b4c03d67a