### PR TITLE
feat: add record FAB

### DIFF
--- a/shared/ui/BottomNav.tsx
+++ b/shared/ui/BottomNav.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import FabRecord from './FabRecord';
 
 /** Bottom navigation bar that hides on scroll down.
  * Visible only on screens up to 600px wide.
@@ -19,30 +20,33 @@ export const BottomNav: React.FC = () => {
   }, []);
 
   return (
-    <nav
-      className={`fixed bottom-0 left-0 right-0 flex justify-around bg-gray-100 dark:bg-gray-800 p-2 transition-transform duration-300 motion-reduce:transition-none sm:hidden ${hidden ? 'translate-y-full' : ''}`}
-    >
-      <a
-        href="/"
-        aria-label="Home"
-        className="text-gray-900 dark:text-gray-100 focus:outline-none focus:ring"
+    <>
+      <nav
+        className={`fixed bottom-0 left-0 right-0 flex justify-around bg-gray-100 dark:bg-gray-800 p-2 transition-transform duration-300 motion-reduce:transition-none sm:hidden ${hidden ? 'translate-y-full' : ''}`}
       >
-        Home
-      </a>
-      <a
-        href="/record"
-        aria-label="Record"
-        className="text-2xl text-gray-900 dark:text-gray-100 focus:outline-none focus:ring"
-      >
-        +
-      </a>
-      <a
-        href="/profile"
-        aria-label="Profile"
-        className="text-gray-900 dark:text-gray-100 focus:outline-none focus:ring"
-      >
-        Profile
-      </a>
-    </nav>
+        <a
+          href="/"
+          aria-label="Home"
+          className="text-gray-900 dark:text-gray-100 focus:outline-none focus:ring"
+        >
+          Home
+        </a>
+        <a
+          href="/record"
+          aria-label="Record"
+          className="text-2xl text-gray-900 dark:text-gray-100 focus:outline-none focus:ring"
+        >
+          +
+        </a>
+        <a
+          href="/profile"
+          aria-label="Profile"
+          className="text-gray-900 dark:text-gray-100 focus:outline-none focus:ring"
+        >
+          Profile
+        </a>
+      </nav>
+      <FabRecord />
+    </>
   );
 };

--- a/shared/ui/FabRecord.tsx
+++ b/shared/ui/FabRecord.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+declare const navigate: (path: string) => void;
+
+const FabRecord: React.FC = () => {
+  const handleClick = () => {
+    navigate('/record');
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      aria-label="Record"
+      className="fixed bottom-16 left-1/2 -translate-x-1/2 z-50 flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-r from-[#FF0759] to-[#FF8A90] text-white drop-shadow-lg sm:hidden"
+    >
+      +
+    </button>
+  );
+};
+
+export default FabRecord;

--- a/shared/ui/index.ts
+++ b/shared/ui/index.ts
@@ -36,3 +36,4 @@ export * from './QuotaBar';
 export * from './BackupSeedBtn';
 export * from './Settings';
 export * from './PostMenu';
+export { default as FabRecord } from './FabRecord';

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,4 +1,6 @@
 /** @type {import('tailwindcss').Config} */
+const plugin = require('tailwindcss/plugin');
+
 module.exports = {
   content: [
     './apps/**/*.{ts,tsx,js,jsx}',
@@ -30,5 +32,14 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [
+    plugin(function ({ addUtilities }) {
+      addUtilities({
+        '.drop-shadow-lg': {
+          filter:
+            'drop-shadow(0 10px 8px rgba(0 0 0 / 0.04)) drop-shadow(0 4px 3px rgba(0 0 0 / 0.1))',
+        },
+      });
+    }),
+  ],
 };


### PR DESCRIPTION
## Summary
- add floating record button component with gradient and drop shadow
- show the new FAB alongside existing bottom navigation
- include drop shadow utility via Tailwind plugin

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ea458ed708331a52a4d4d228f8b23