### PR TITLE
feat: add discover route and top tags

### DIFF
--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -5,6 +5,7 @@ import SettingsNetwork from './routes/SettingsNetwork';
 import SettingsStorage from './routes/SettingsStorage';
 import SettingsProfile from './routes/SettingsProfile';
 import SearchResults from './routes/SearchResults';
+import Discover from './routes/Discover';
 
 export const ROUTES: Record<string, React.FC> = {
   '/compose': Compose,
@@ -12,6 +13,7 @@ export const ROUTES: Record<string, React.FC> = {
   '/settings/storage': SettingsStorage,
   '/settings/profile': SettingsProfile,
   '/search': SearchResults,
+  '/discover': Discover,
   '/': Compose,
 };
 

--- a/apps/web/src/routes/Discover.tsx
+++ b/apps/web/src/routes/Discover.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { createRPCClient } from '../../../shared/rpc';
+import type { Post } from '../../../shared/types';
+import { useSearch } from '../../../shared/store/search';
+import { TimelineCard } from '../../../shared/ui';
+
+interface TagCount { tag: string; count: number }
+
+export default function Discover() {
+  const [tags, setTags] = useState<TagCount[]>([]);
+  const [posts, setPosts] = useState<Post[]>([]);
+  const rpcRef = useRef<ReturnType<typeof createRPCClient>>();
+  const { setOpen, setQ } = useSearch();
+
+  useEffect(() => {
+    const worker = new Worker(
+      new URL('../../../../packages/worker-ssb/index.ts', import.meta.url),
+      { type: 'module' }
+    );
+    const rpc = createRPCClient(worker);
+    rpcRef.current = rpc;
+    rpc('topTags', { since: Date.now() - 48 * 60 * 60 * 1000, limit: 20 }).then((t) =>
+      setTags(t as TagCount[])
+    );
+    rpc('queryFeed', {}).then((p) => setPosts(p as Post[]));
+    return () => worker.terminate();
+  }, []);
+
+  const onTag = (tag: string) => {
+    setOpen(true);
+    setQ('#' + tag);
+    window.history.pushState(null, '', '/search');
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex gap-2 overflow-x-auto pb-2">
+        {tags.map((t) => (
+          <button
+            key={t.tag}
+            onClick={() => onTag(t.tag)}
+            className="shrink-0 rounded-full bg-gray-200 px-3 py-1"
+          >
+            #{t.tag}
+          </button>
+        ))}
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {posts.map((post) => (
+          <TimelineCard
+            key={post.id}
+            name={post.author.name}
+            avatarUrl={post.author.avatarUrl}
+            text={post.text}
+            magnet={post.magnet}
+            nsfw={post.nsfw}
+            postId={post.id}
+            authorPubKey={post.author.pubkey}
+            reports={post.reports?.length ?? 0}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/packages/worker-ssb/__tests__/topTags.test.ts
+++ b/packages/worker-ssb/__tests__/topTags.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createRPCClient } from '../../../shared/rpc';
+
+vi.mock('../src/instance', () => ({
+  getSSB: () => ({ db: { publish: () => {} }, blobs: { add: () => ({ write() {}, end(cb:any){cb(null,'hash')} }), get: vi.fn(), rm: vi.fn() } })
+}));
+
+function createPortPair() {
+  const listeners1: ((ev: MessageEvent) => void)[] = [];
+  const listeners2: ((ev: MessageEvent) => void)[] = [];
+  const port1 = {
+    postMessage(data: any) {
+      listeners2.forEach((l) => l({ data } as MessageEvent));
+    },
+    addEventListener(_type: 'message', listener: (ev: MessageEvent) => void) {
+      listeners1.push(listener);
+    },
+    removeEventListener(_type: 'message', listener: (ev: MessageEvent) => void) {
+      const idx = listeners1.indexOf(listener);
+      if (idx >= 0) listeners1.splice(idx, 1);
+    },
+    start() {},
+  } as any;
+  const port2 = {
+    postMessage(data: any) {
+      listeners1.forEach((l) => l({ data } as MessageEvent));
+    },
+    addEventListener(_type: 'message', listener: (ev: MessageEvent) => void) {
+      listeners2.push(listener);
+    },
+    removeEventListener(_type: 'message', listener: (ev: MessageEvent) => void) {
+      const idx = listeners2.indexOf(listener);
+      if (idx >= 0) listeners2.splice(idx, 1);
+    },
+    start() {},
+  } as any;
+  return { port1, port2 };
+}
+
+async function setup() {
+  vi.resetModules();
+  (globalThis as any).__cashuSSBLog = [];
+  const { port1, port2 } = createPortPair();
+  (globalThis as any).self = port1;
+  await import('../index');
+  const call = createRPCClient(port2);
+  const cleanup = () => { delete (globalThis as any).self; };
+  return { call, cleanup };
+}
+
+describe('worker-ssb topTags', () => {
+  it('returns most frequent tags', async () => {
+    const { call, cleanup } = await setup();
+    await call('publishPost', {
+      id: '1',
+      author: { name: 'A', pubkey: 'a', avatarUrl: '' },
+      magnet: 'magnet:?xt=urn:btih:a',
+      tags: ['x', 'y'],
+    });
+    await call('publishPost', {
+      id: '2',
+      author: { name: 'B', pubkey: 'b', avatarUrl: '' },
+      magnet: 'magnet:?xt=urn:btih:b',
+      tags: ['x'],
+    });
+    const tags = (await call('topTags', { since: 0, limit: 10 })) as any[];
+    expect(tags[0]).toEqual({ tag: 'x', count: 2 });
+    cleanup();
+  });
+});
+

--- a/packages/worker-ssb/index.ts
+++ b/packages/worker-ssb/index.ts
@@ -83,6 +83,23 @@ createRPCHandler(self as any, {
       return reporters.size < threshold;
     });
   },
+  topTags: async (opts) => {
+    const since = opts?.since ?? Date.now() - 48 * 60 * 60 * 1000;
+    const limit = opts?.limit ?? 20;
+    const posts = ssbLog.filter(
+      (m) => m.type === 'post' && (m.ts ?? 0) >= since
+    );
+    const counts: Record<string, number> = {};
+    for (const p of posts) {
+      for (const t of p.tags ?? []) {
+        counts[t] = (counts[t] || 0) + 1;
+      }
+    }
+    return Object.entries(counts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, limit)
+      .map(([tag, count]) => ({ tag, count }));
+  },
   searchPosts: async (query: string, limit = 20) => {
     const results = mini.search(query, { prefix: true }).slice(0, limit);
     const posts = new Map(

--- a/shared/rpc/index.ts
+++ b/shared/rpc/index.ts
@@ -4,6 +4,10 @@ import { PostSchema } from '../types';
 
 // Placeholder schemas for complex types
 const QueryOpts = z.object({ includeTags: z.array(z.string()).optional() });
+const TopTagsOpts = z.object({
+  since: z.number().optional(),
+  limit: z.number().optional(),
+});
 const FileSchema = z.any();
 const Magnet = z.any();
 
@@ -13,6 +17,7 @@ export const MethodDefinitions = {
   reportPost: z.tuple([z.string(), z.string()]),
   blockUser: z.tuple([z.string()]),
   searchPosts: z.tuple([z.string(), z.number().optional()]),
+  topTags: z.tuple([TopTagsOpts]),
   seedFile: z.tuple([FileSchema]),
   stream: z.tuple([Magnet]),
   mint: z.tuple([z.number()]),
@@ -27,6 +32,7 @@ export const MethodsSchema = z.union([
   z.object({ ns: z.literal('ssb'), fn: z.literal('reportPost'), args: MethodDefinitions.reportPost }),
   z.object({ ns: z.literal('ssb'), fn: z.literal('blockUser'), args: MethodDefinitions.blockUser }),
   z.object({ ns: z.literal('ssb'), fn: z.literal('searchPosts'), args: MethodDefinitions.searchPosts }),
+  z.object({ ns: z.literal('ssb'), fn: z.literal('topTags'), args: MethodDefinitions.topTags }),
   z.object({ ns: z.literal('ssb'), fn: z.literal('initKeys'), args: MethodDefinitions.initKeys }),
   z.object({ ns: z.literal('torrent'), fn: z.literal('seedFile'), args: MethodDefinitions.seedFile }),
   z.object({ ns: z.literal('torrent'), fn: z.literal('stream'), args: MethodDefinitions.stream }),
@@ -58,6 +64,7 @@ const methodArgSchemas: Record<MethodName, z.ZodTuple<any, any>> = {
   reportPost: MethodDefinitions.reportPost,
   blockUser: MethodDefinitions.blockUser,
   searchPosts: MethodDefinitions.searchPosts,
+  topTags: MethodDefinitions.topTags,
   seedFile: MethodDefinitions.seedFile,
   stream: MethodDefinitions.stream,
   mint: MethodDefinitions.mint,

--- a/shared/ui/BottomNav.test.tsx
+++ b/shared/ui/BottomNav.test.tsx
@@ -7,6 +7,7 @@ describe('BottomNav', () => {
   it('renders navigation links', () => {
     const html = renderToStaticMarkup(<BottomNav />);
     expect(html).toContain('Home');
+    expect(html).toContain('href="/discover"');
     expect(html).toContain('+');
     expect(html).toContain('Profile');
   });

--- a/shared/ui/BottomNav.tsx
+++ b/shared/ui/BottomNav.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import FabRecord from './FabRecord';
+import { Compass } from 'lucide-react';
 
 /** Bottom navigation bar that hides on scroll down.
  * Visible only on screens up to 600px wide.
@@ -30,6 +31,14 @@ export const BottomNav: React.FC = () => {
           className="text-gray-900 dark:text-gray-100 focus:outline-none focus:ring"
         >
           Home
+        </a>
+        <a
+          href="/discover"
+          aria-label="Discover"
+          className="text-gray-900 dark:text-gray-100 focus:outline-none focus:ring"
+        >
+          <Compass className="mx-auto" />
+          <span className="sr-only">Discover</span>
         </a>
         <a
           href="/record"


### PR DESCRIPTION
## Summary
- add topTags RPC and worker implementation
- show tag chips and grid on new Discover page
- add Discover to router and bottom nav

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688ea9a9f25083319ae0968330d7e1af