### PR TITLE
feat: add consolidated settings overlay

### DIFF
--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
 import Onboarding from './routes/Onboarding';
 import Compose from './routes/Compose';
-import SettingsNetwork from './routes/SettingsNetwork';
-import SettingsStorage from './routes/SettingsStorage';
-import SettingsProfile from './routes/SettingsProfile';
+import SettingsOverlay from './routes/SettingsOverlay';
 import SearchResults from './routes/SearchResults';
 import Discover from './routes/Discover';
 
 export const ROUTES: Record<string, React.FC> = {
   '/compose': Compose,
-  '/settings/network': SettingsNetwork,
-  '/settings/storage': SettingsStorage,
-  '/settings/profile': SettingsProfile,
+  '/settings': SettingsOverlay,
   '/search': SearchResults,
   '/discover': Discover,
   '/': Compose,

--- a/apps/web/src/routes/SettingsAppearance.tsx
+++ b/apps/web/src/routes/SettingsAppearance.tsx
@@ -1,6 +1,6 @@
 import { useProfile } from '../../shared/store/profile';
 
-export default function SettingsProfile() {
+export const SettingsAppearance: React.FC = () => {
   const exportProfile = useProfile((s) => s.exportProfile);
 
   const onExport = () => {
@@ -23,7 +23,7 @@ export default function SettingsProfile() {
 
   return (
     <div className="p-4 space-y-4">
-      <h2 className="text-xl font-semibold">Profile</h2>
+      <h2 className="text-xl font-semibold">Appearance</h2>
       <div className="space-x-2">
         <button
           onClick={onExport}
@@ -40,5 +40,7 @@ export default function SettingsProfile() {
       </div>
     </div>
   );
-}
+};
+
+
 

--- a/apps/web/src/routes/SettingsNetwork.tsx
+++ b/apps/web/src/routes/SettingsNetwork.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useSettings } from '../../shared/store/settings';
 
-export default function SettingsNetwork() {
+export const SettingsNetwork: React.FC = () => {
   const {
     roomUrl,
     trackerUrls,
@@ -67,5 +67,5 @@ export default function SettingsNetwork() {
       </label>
     </div>
   );
-}
+};
 

--- a/apps/web/src/routes/SettingsOverlay.tsx
+++ b/apps/web/src/routes/SettingsOverlay.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { SettingsStorage } from './SettingsStorage';
+import { SettingsNetwork } from './SettingsNetwork';
+import { SettingsAppearance } from './SettingsAppearance';
+
+export default function SettingsOverlay() {
+  const [tab, setTab] = React.useState<'storage' | 'network' | 'appearance'>('storage');
+
+  return (
+    <Dialog.Root open onOpenChange={(o) => { if (!o) window.history.back(); }}>
+      <Dialog.Overlay className="fixed inset-0 bg-black/50" />
+      <Dialog.Content className="fixed inset-0 flex flex-col bg-white dark:bg-gray-900">
+        <header className="flex items-center justify-between border-b p-4">
+          <h1 className="text-xl font-semibold">Settings</h1>
+          <Dialog.Close aria-label="Close" className="text-xl">×</Dialog.Close>
+        </header>
+        <nav className="flex border-b">
+          <button
+            className={`flex-1 p-2 ${tab === 'storage' ? 'border-b-2 border-primary' : ''}`}
+            onClick={() => setTab('storage')}
+          >
+            Storage
+          </button>
+          <button
+            className={`flex-1 p-2 ${tab === 'network' ? 'border-b-2 border-primary' : ''}`}
+            onClick={() => setTab('network')}
+          >
+            Network
+          </button>
+          <button
+            className={`flex-1 p-2 ${tab === 'appearance' ? 'border-b-2 border-primary' : ''}`}
+            onClick={() => setTab('appearance')}
+          >
+            Appearance
+          </button>
+        </nav>
+        <div className="flex-1 overflow-y-auto">
+          {tab === 'storage' && <SettingsStorage />}
+          {tab === 'network' && <SettingsNetwork />}
+          {tab === 'appearance' && <SettingsAppearance />}
+        </div>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/apps/web/src/routes/SettingsStorage.tsx
+++ b/apps/web/src/routes/SettingsStorage.tsx
@@ -1,7 +1,7 @@
 import { useSettings } from '../../shared/store/settings';
 import { setMaxCacheMB } from '../../../packages/worker-ssb/src/blobCache';
 
-export default function SettingsStorage() {
+export const SettingsStorage: React.FC = () => {
   const { maxBlobMB, setMaxBlobMB } = useSettings();
   return (
     <div className="p-4 space-y-4">
@@ -25,4 +25,5 @@ export default function SettingsStorage() {
       </label>
     </div>
   );
-}
+};
+


### PR DESCRIPTION
## Summary
- consolidate storage, network, and appearance settings into a single overlay
- expose individual settings sections as reusable components
- update router to point `/settings` at the new overlay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688eaf6746288331b2dc8c0af7d57f55