### PR TITLE
feat: add boost badge

### DIFF
--- a/apps/web/src/components/BoostBadge.tsx
+++ b/apps/web/src/components/BoostBadge.tsx
@@ -1,0 +1,9 @@
+export default function BoostBadge({users}:{users:string[]}) {
+  if(!users.length) return null;
+  return (
+    <div className="flex items-center gap-1 text-sm text-white/80">
+      ↻ {users.length}
+      {/* hover → absolute grid of avatar imgs */}
+    </div>
+  );
+}

--- a/apps/web/src/components/TimelineCard.tsx
+++ b/apps/web/src/components/TimelineCard.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../../shared/ui';
 import { MessageCircle } from 'lucide-react';
 import { CommentsDrawer } from './CommentsDrawer';
+import BoostBadge from './BoostBadge';
 import { motion } from 'framer-motion';
 import { createRPCClient } from '../../../shared/rpc';
 
@@ -35,6 +36,8 @@ export interface TimelineCardProps {
   onBlock?: (pubKey: string) => void;
   /** Number of reports on the post */
   reports?: number;
+  /** Users who reposted this post */
+  boosters?: string[];
   /** Whether the current viewer is a moderator */
   isModerator?: boolean;
 }
@@ -50,6 +53,7 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({
   onReport,
   onBlock,
   reports = 0,
+  boosters = [],
   isModerator,
 }) => {
   const showNSFW = useSettingsStore((s) => s.showNSFW);
@@ -140,6 +144,7 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({
                   ↻
                 </button>
               )}
+              <BoostBadge users={boosters} />
               {authorPubKey && postId && (
                 <ZapButton receiverPk={authorPubKey} refId={postId} />
               )}

--- a/apps/web/src/routes/Discover.tsx
+++ b/apps/web/src/routes/Discover.tsx
@@ -57,6 +57,7 @@ export default function Discover() {
             postId={post.id}
             authorPubKey={post.author.pubkey}
             reports={post.reports?.length ?? 0}
+            boosters={post.boosters}
           />
         ))}
       </div>

--- a/apps/web/src/routes/SearchResults.tsx
+++ b/apps/web/src/routes/SearchResults.tsx
@@ -20,6 +20,7 @@ export default function SearchResults() {
             postId={post.id}
             authorPubKey={post.author.pubkey}
             reports={post.reports?.length ?? 0}
+            boosters={post.boosters}
           />
         ))
       )}

--- a/shared/types/post.ts
+++ b/shared/types/post.ts
@@ -24,6 +24,15 @@ export const PostSchema = z.object({
     })
     .array()
     .optional(),
+  /** Users who reposted this post */
+  boosters: z
+    .object({
+      name: z.string(),
+      pubkey: z.string(),
+      avatarUrl: z.string(),
+    })
+    .array()
+    .optional(),
 });
 
 export interface Post {
@@ -40,5 +49,6 @@ export interface Post {
   nsfw?: boolean;
   ts: number;
   reports?: { fromPk: string; reason: string; ts: number }[];
+  boosters?: { name: string; pubkey: string; avatarUrl: string }[];
 }
 


### PR DESCRIPTION
## Summary
- display boost count with new BoostBadge component
- accept booster lists in TimelineCard and show BoostBadge
- plumb boosters data through routes and shared Post type

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688eb91e08288331abd41046904613d3