### PR TITLE
test: add BoostBadge component tests

### DIFF
--- a/apps/web/src/components/BoostBadge.test.tsx
+++ b/apps/web/src/components/BoostBadge.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import BoostBadge from './BoostBadge';
+
+describe('BoostBadge', () => {
+  it('returns null when no users', () => {
+    const result = renderToString(<BoostBadge users={[]} />);
+    expect(result).toBe('');
+  });
+
+  it('displays a count when users are present', () => {
+    const result = renderToString(<BoostBadge users={['a', 'b']} />);
+    const clean = result.replace(/<!--.*?-->/g, '');
+    expect(clean).toContain('↻ 2');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for BoostBadge to verify count rendering and empty state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ebc603d08833199ed2d0afd376f84