### PR TITLE
feat: track video playback in history

### DIFF
--- a/apps/web/src/components/TimelineCard.tsx
+++ b/apps/web/src/components/TimelineCard.tsx
@@ -89,7 +89,7 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4 }}
       >
-        <VideoPlayer magnet={magnet} />
+        <VideoPlayer magnet={magnet} postId={postId} />
         {hidden && (
           <BlurOverlay
             aria-label="NSFW content hidden"

--- a/shared/store/history.ts
+++ b/shared/store/history.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type V = { ts: number };
+
+interface HistoryState {
+  map: Record<string, V>;
+  add: (id: string) => void;
+}
+
+export const useHistory = create<HistoryState>()(
+  persist(
+    (set, get) => ({
+      map: {},
+      add: (id: string) =>
+        set((s) => {
+          const now = Date.now();
+          return { map: { ...s.map, [id]: { ts: now } } };
+        }),
+    }),
+    { name: 'timeline-history', version: 1 },
+  ),
+);

--- a/shared/ui/TimelineCard.tsx
+++ b/shared/ui/TimelineCard.tsx
@@ -71,7 +71,7 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4 }}
       >
-        <VideoPlayer magnet={magnet} />
+        <VideoPlayer magnet={magnet} postId={postId} />
         {hidden && (
           <BlurOverlay
             aria-label="NSFW content hidden"

--- a/shared/ui/VideoPlayer.tsx
+++ b/shared/ui/VideoPlayer.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { createRPCClient } from '../rpc';
 import { SkeletonLoader } from './SkeletonLoader';
+import { useHistory } from '../store/history';
 
 export interface VideoPlayerProps {
   /** Magnet link for the video stream */
   magnet: string;
+  /** Post identifier for history tracking */
+  postId?: string;
 }
 
 /**
@@ -13,7 +16,7 @@ export interface VideoPlayerProps {
  * displayed to avoid layout shifts. The resulting video autoplays muted so it
  * can start without user interaction.
  */
-export const VideoPlayer: React.FC<VideoPlayerProps> = ({ magnet }) => {
+export const VideoPlayer: React.FC<VideoPlayerProps> = ({ magnet, postId }) => {
   const [src, setSrc] = React.useState<string | null>(null);
 
   React.useEffect(() => {
@@ -58,6 +61,9 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({ magnet }) => {
       muted
       loop
       autoPlay
+      onPlay={() => {
+        if (postId) useHistory.getState().add(postId);
+      }}
     />
   );
 };


### PR DESCRIPTION
## Summary
- add persistent playback history store
- track post plays from VideoPlayer

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ebeb559108331b4637193d2f71e66