### PR TITLE
Filter out recently viewed posts from feed

### DIFF
--- a/shared/store/history-worker.ts
+++ b/shared/store/history-worker.ts
@@ -1,0 +1,17 @@
+export async function get(since: number): Promise<Set<string>> {
+  try {
+    const ls: any = (globalThis as any).localStorage;
+    if (!ls) return new Set();
+    const raw = ls.getItem('timeline-history');
+    if (!raw) return new Set();
+    const data = JSON.parse(raw);
+    const map = data?.state?.map ?? data?.map ?? {};
+    const out = new Set<string>();
+    for (const [id, v] of Object.entries<any>(map)) {
+      if ((v?.ts ?? 0) >= since) out.add(id);
+    }
+    return out;
+  } catch (_) {
+    return new Set();
+  }
+}


### PR DESCRIPTION
## Summary
- skip posts the user viewed in the last 48h when generating worker SSB feed
- add helper to read timeline history from localStorage

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688ec005b7588331a6609f508047eb59