### PR TITLE
feat: add reactive boost badge

### DIFF
--- a/apps/web/src/components/BoostBadge.test.tsx
+++ b/apps/web/src/components/BoostBadge.test.tsx
@@ -1,16 +1,18 @@
 import { describe, it, expect } from 'vitest';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
-import BoostBadge from './BoostBadge';
+import BoostBadge, { setBoosters } from './BoostBadge';
 
 describe('BoostBadge', () => {
-  it('returns null when no users', () => {
-    const result = renderToString(<BoostBadge users={[]} />);
+  it('returns null when no boosters', () => {
+    setBoosters('p1', []);
+    const result = renderToString(<BoostBadge id="p1" />);
     expect(result).toBe('');
   });
 
-  it('displays a count when users are present', () => {
-    const result = renderToString(<BoostBadge users={['a', 'b']} />);
+  it('displays a count when boosters are present', () => {
+    setBoosters('p2', ['a', 'b']);
+    const result = renderToString(<BoostBadge id="p2" />);
     const clean = result.replace(/<!--.*?-->/g, '');
     expect(clean).toContain('↻ 2');
   });

--- a/apps/web/src/components/BoostBadge.tsx
+++ b/apps/web/src/components/BoostBadge.tsx
@@ -1,9 +1,52 @@
-export default function BoostBadge({users}:{users:string[]}) {
-  if(!users.length) return null;
+import { useSyncExternalStore } from 'react';
+
+type Callback = () => void;
+
+const listeners = new Map<string, Set<Callback>>();
+
+export const boosterMap = new Map<string, string[]>();
+
+export const subs = {
+  add(id: string, cb: Callback) {
+    const set = listeners.get(id) || new Set<Callback>();
+    set.add(cb);
+    listeners.set(id, set);
+    return () => {
+      set.delete(cb);
+      if (!set.size) listeners.delete(id);
+    };
+  },
+};
+
+export function setBoosters(id: string, users: string[]) {
+  boosterMap.set(id, users);
+  const set = listeners.get(id);
+  if (set) {
+    for (const cb of set) cb();
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('message', (e: MessageEvent) => {
+    const data: any = e.data;
+    if (data && data.type === 'boosters') {
+      setBoosters(data.id, data.users || []);
+    }
+  });
+}
+
+export default function BoostBadge({ id }: { id: string }) {
+  const boosters = useSyncExternalStore(
+    (cb) => subs.add(id, cb),
+    () => boosterMap.get(id) || [],
+    () => boosterMap.get(id) || []
+  );
+  if (!boosters.length) return null;
   return (
     <div className="flex items-center gap-1 text-sm text-white/80">
-      ↻ {users.length}
+      ↻ {boosters.length}
       {/* hover → absolute grid of avatar imgs */}
     </div>
   );
 }
+

--- a/apps/web/src/components/TimelineCard.tsx
+++ b/apps/web/src/components/TimelineCard.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../../shared/ui';
 import { MessageCircle } from 'lucide-react';
 import { CommentsDrawer } from './CommentsDrawer';
-import BoostBadge from './BoostBadge';
+import BoostBadge, { setBoosters } from './BoostBadge';
 import { motion } from 'framer-motion';
 import { createRPCClient } from '../../../shared/rpc';
 
@@ -62,6 +62,10 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({
   const [profileOpen, setProfileOpen] = React.useState(false);
   const [commentsOpen, setCommentsOpen] = React.useState(false);
   const rpcRef = React.useRef<ReturnType<typeof createRPCClient> | null>(null);
+
+  React.useEffect(() => {
+    if (postId) setBoosters(postId, boosters);
+  }, [postId, boosters]);
 
   React.useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -144,7 +148,7 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({
                   ↻
                 </button>
               )}
-              <BoostBadge users={boosters} />
+              {postId && <BoostBadge id={postId} />}
               {authorPubKey && postId && (
                 <ZapButton receiverPk={authorPubKey} refId={postId} />
               )}


### PR DESCRIPTION
## Summary
- add external booster store and reactive BoostBadge component
- seed booster data in TimelineCard and switch to id prop
- update BoostBadge tests for new contract

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688ec1498970833181d2a40a2d4f3c01