### PR TITLE
docs: expand readme and document worker modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,75 @@
 # CashuCast
 
+CashuCast is a peer-to-peer media platform that combines [Cashu](https://cashu.space/) e-cash payments with
+[Secure Scuttlebutt](https://scuttlebutt.nz/) and BitTorrent distribution.  The project ships as a browser-based
+React application backed by a collection of web workers for wallet, gossip and torrent functionality.
+
+## Features
+
+- ⚡ **Integrated Cashu wallet** for minting and sending tokens.
+- 📡 **Secure Scuttlebutt identity** and gossip network for discovering peers.
+- 🌊 **BitTorrent-powered blob sharing** for media distribution.
+- 🧩 Modular worker architecture (`worker-*` packages) enabling isolated, testable logic.
+- 🧪 `vitest` unit tests and Playwright component tests.
+
 ## Development environment
 
-Bootstrap the project on a fresh Linux machine by running:
+Bootstrap a fresh Linux machine with all dependencies by running:
 
 ```bash
 ./scripts/setup_dev_env.sh
 ```
 
-The script verifies Linux, installs Node.js 20, pnpm, Docker (with the compose plugin), and installs project dependencies using `pnpm install --frozen-lockfile`.
+The script installs Node.js 20, pnpm and a container engine (Docker or Podman) before running
+`pnpm install --frozen-lockfile`.
+
+To start the development stack manually:
+
+```bash
+./scripts/dev.sh
+```
+
+This boots supporting containers (room server, tracker and regtest mint), installs dependencies and runs the
+Vite development server for the web app.
+
+## Running tests
+
+Unit tests can be run with the helper script:
+
+```bash
+./scripts/test.sh
+```
+
+It wraps the `pnpm test` command and prints friendly status messages before and after execution.
+
+## Deploying to a server
+
+A one-shot installer is provided for Ubuntu 24.04 VPS environments.  On a fresh server run:
+
+```bash
+curl -sL https://raw.githubusercontent.com/<your-org>/cashucast/main/scripts/install_server.sh | bash
+```
+
+The script installs Caddy, a container runtime, fetches this repository and launches the production Docker
+Compose stack located under `infra/docker`.
+
+## Helper scripts
+
+The `scripts/` directory contains small utilities with user-friendly output:
+
+| Script | Description |
+| ------ | ----------- |
+| `build.sh` | Build the production web bundle and worker packages. |
+| `dev.sh` | Start local containers and run the web app with hot reload. |
+| `install_server.sh` | Provision and launch the application on an Ubuntu server. |
+| `quicktest.sh` | Spin up the development stack and expose it on the LAN. |
+| `setup_dev_env.sh` | Install Node.js, pnpm and a container engine on Linux. |
+| `test.sh` | Run unit tests with status messages. |
+
+Additional helper scripts can be added to this folder as needed, for example to run linting, database
+migrations or other maintenance tasks.  Make sure each script prints clear feedback so developers know what
+is happening and when the task has finished.
+
+## Contributing
+
+Contributions are welcome!  Please run `./scripts/test.sh` before submitting a pull request.

--- a/packages/stats-worker/index.ts
+++ b/packages/stats-worker/index.ts
@@ -1,7 +1,17 @@
-import ky from 'kyou';            // 4 kB fetch wrapper
+/**
+ * Background worker that periodically polls a tracker for swarm statistics and
+ * relays them to the UI thread.
+ */
+import ky from 'kyou'; // 4 kB fetch wrapper
 export type CountMap = Record<string /*infoHash*/, number>;
 
 let cache: CountMap = {};
+
+/**
+ * Fetch the latest peer counts from a tracker and cache the results.
+ *
+ * @param endpoint - Base URL of the tracker API.
+ */
 export async function refresh(endpoint: string) {
   try {
     const json = await ky.get(`${endpoint}/stats`).json<any>();

--- a/packages/worker-cashu/index.ts
+++ b/packages/worker-cashu/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Web worker that exposes Cashu minting utilities over a simple RPC interface.
+ * Methods defined here are consumed by the main application thread to mint and
+ * send e-cash tokens without blocking the UI.
+ */
 import { createRPCHandler } from '../../shared/rpc';
 import { generateMnemonic, mnemonicToSeedSync } from 'bip39';
 import {
@@ -15,6 +20,12 @@ let proofs: Proof[] = (globalThis as any).__cashuProofs || [];
 (globalThis as any).__cashuProofs = proofs;
 
 createRPCHandler(self as any, {
+  /**
+   * Mint new e-cash proofs from the configured Cashu mint.
+   *
+   * @param sats - Amount in satoshis to mint.
+   * @returns Total value of proofs obtained from the mint.
+   */
   mint: async (sats: number) => {
     if (!wallet) throw new Error('wallet not initialized');
     const quote = await wallet.createMintQuote(sats);
@@ -27,6 +38,14 @@ createRPCHandler(self as any, {
     (globalThis as any).__cashuProofs = proofs;
     return newProofs.reduce((sum, p) => sum + p.amount, 0);
   },
+  /**
+   * Send a "zap" payment to a receiver by creating a token transfer.
+   *
+   * @param receiverPk - Public key of the receiver.
+   * @param sats - Amount in satoshis to transfer.
+   * @param refId - Reference identifier for the zap event.
+   * @returns Object containing the zap details and encoded token.
+   */
   sendZap: async (receiverPk: string, sats: number, refId: string) => {
     if (!wallet) throw new Error('wallet not initialized');
     const { send, keep } = await wallet.send(sats, proofs);
@@ -35,6 +54,13 @@ createRPCHandler(self as any, {
     const token = getEncodedTokenV4({ mint: MINT_URL, proofs: send });
     return { receiverPk, sats, refId, token };
   },
+  /**
+   * Initialise the wallet for the worker. If a mnemonic is not provided a new
+   * one will be generated and returned to the caller.
+   *
+   * @param mnemonic - Optional BIP39 seed phrase to load.
+   * @returns The mnemonic used for the wallet.
+   */
   initWallet: async (mnemonic?: string) => {
     const phrase = mnemonic ?? generateMnemonic();
     const seed = mnemonicToSeedSync(phrase);

--- a/scripts/quicktest.sh
+++ b/scripts/quicktest.sh
@@ -2,6 +2,9 @@
 set -e
 
 # ── Detect runtimes & health ───────────────────────────────────
+# check_runtime <binary>
+# Prints "ok", "broken" or "absent" depending on the availability
+# and health of the container runtime.
 check_runtime() {
   local bin=$1
   if ! command -v $bin >/dev/null 2>&1; then
@@ -18,6 +21,9 @@ check_runtime() {
 docker_state=$(check_runtime docker)   # ok / broken / absent
 podman_state=$(check_runtime podman)   # ok / broken / absent
 
+# choose_runtime
+# Prompt the user to pick a container runtime when both Docker
+# and Podman are healthy on the system.
 choose_runtime() {
   # Both ok → prompt
   read -n1 -r -p "Both Docker and Podman detected. Use (d)ocker or (p)odman? [d]: " choice

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Run the Vitest suite with friendly output
+set -e
+
+echo "🧪  Running unit tests…"
+
+pnpm test
+
+echo -e "\n✅  Tests finished"

--- a/shared/store/filters.ts
+++ b/shared/store/filters.ts
@@ -1,10 +1,18 @@
 import { create } from 'zustand';
 
+/**
+ * State for managing active tag filters in the timeline view.
+ */
 interface FilterState {
+  /** Currently selected tags to filter by. */
   tags: string[];
+  /** Add or remove a tag from the filter set. */
   toggleTag: (t: string) => void;
 }
 
+/**
+ * Parse the hash fragment of the URL and extract the `tags` parameter.
+ */
 function readTagsFromHash(): string[] {
   if (typeof window === 'undefined') return [];
   const match = window.location.hash.match(/tags=([^&]+)/);
@@ -17,6 +25,9 @@ function readTagsFromHash(): string[] {
   return [];
 }
 
+/**
+ * Persist the current tag selection into the URL hash to allow link sharing.
+ */
 function writeTagsToHash(tags: string[]) {
   if (typeof window === 'undefined') return;
   const hash = tags.length
@@ -25,6 +36,9 @@ function writeTagsToHash(tags: string[]) {
   window.history.replaceState(null, '', hash);
 }
 
+/**
+ * Zustand store encapsulating tag filter state.
+ */
 export const useFilters = create<FilterState>((set, get) => ({
   tags: readTagsFromHash(),
   toggleTag(t) {

--- a/shared/store/history-worker.ts
+++ b/shared/store/history-worker.ts
@@ -1,3 +1,10 @@
+/**
+ * Retrieve IDs of timeline items seen since the given timestamp. The data is
+ * read from localStorage allowing the main thread to filter out recently seen
+ * posts while running inside a worker.
+ *
+ * @param since - Timestamp (ms) after which items are considered recent.
+ */
 export async function get(since: number): Promise<Set<string>> {
   try {
     const ls: any = (globalThis as any).localStorage;

--- a/shared/store/history.ts
+++ b/shared/store/history.ts
@@ -3,11 +3,20 @@ import { persist } from 'zustand/middleware';
 
 type V = { ts: number };
 
+/**
+ * Tracks which post IDs have been seen recently to avoid re-showing them in
+ * the feed.
+ */
 interface HistoryState {
+  /** Mapping of post id to timestamp of last view. */
   map: Record<string, V>;
+  /** Record that a post has been viewed. */
   add: (id: string) => void;
 }
 
+/**
+ * Zustand store used to persist recently viewed posts in localStorage.
+ */
 export const useHistory = create<HistoryState>()(
   persist(
     (set, get) => ({

--- a/shared/store/profile.ts
+++ b/shared/store/profile.ts
@@ -2,13 +2,23 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { Profile } from '../types/profile';
 
+/**
+ * State for managing the user's local profile information.
+ */
 interface ProfileState {
+  /** Current profile data, if any. */
   profile?: Profile;
+  /** Replace the current profile. */
   setProfile: (profile: Profile) => void;
+  /** Load profile data from a JSON export. */
   importProfile: (json: Profile) => void;
+  /** Export the profile to a Blob for downloading. */
   exportProfile: () => Blob;
 }
 
+/**
+ * Persisted profile store backed by localStorage.
+ */
 export const useProfile = create<ProfileState>()(
   persist(
     (set, get) => ({

--- a/shared/store/search.ts
+++ b/shared/store/search.ts
@@ -1,15 +1,24 @@
 import { create } from 'zustand';
 import type { Post } from '../types';
 
+/**
+ * State used by the search dialog for querying posts.
+ */
 interface SearchState {
+  /** Whether the search UI is currently shown. */
   open: boolean;
+  /** Current query string. */
   q: string;
+  /** Search results from the worker. */
   results: Post[];
   setOpen: (v: boolean) => void;
   setQ: (q: string) => void;
   setResults: (r: Post[]) => void;
 }
 
+/**
+ * Zustand store holding search UI state.
+ */
 export const useSearch = create<SearchState>((set) => ({
   open: false,
   q: '',

--- a/shared/store/settings.ts
+++ b/shared/store/settings.ts
@@ -2,6 +2,10 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { getDefaultEndpoints } from '../config';
 
+/**
+ * Global application settings persisted in localStorage. These control how the
+ * application interacts with the network and its moderation behaviour.
+ */
 interface SettingsState {
   showNSFW: boolean;
   maxBlobMB: number;
@@ -18,6 +22,9 @@ interface SettingsState {
   setLowSeedRatio: (n: number) => void;
 }
 
+/**
+ * Zustand store providing read/write access to user settings.
+ */
 export const useSettings = create<SettingsState>()(
   persist(
     (set, get) => {


### PR DESCRIPTION
## Summary
- document CashuCast features, development setup, deployment and helper scripts
- add `scripts/test.sh` for running the Vitest suite with friendly feedback
- clarify quicktest helper functions and document web worker and store modules

## Testing
- `./scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_688eda0fc9188331a2ef5feaaf368085