### PR TITLE
fix: improve container runtime detection

### DIFF
--- a/scripts/quicktest.sh
+++ b/scripts/quicktest.sh
@@ -47,13 +47,22 @@ fi
 
 # ── Compose alias ───────────────────────────────────────────────
 if [[ $CTL == "docker" ]]; then
-  COMPOSE="docker compose"
+  if $CTL compose version >/dev/null 2>&1; then
+    COMPOSE="docker compose"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    COMPOSE="docker-compose"
+  else
+    echo "❌  Docker Compose not found." >&2
+    exit 1
+  fi
 else
-  # prefer 'podman compose' else fallback to podman-compose binary
   if $CTL compose version >/dev/null 2>&1; then
     COMPOSE="podman compose"
-  else
+  elif command -v podman-compose >/dev/null 2>&1; then
     COMPOSE="podman-compose"
+  else
+    echo "❌  Podman Compose not found." >&2
+    exit 1
   fi
 fi
 


### PR DESCRIPTION
## Summary
- handle docker/podman selection in dev and quicktest scripts
- fallback to docker-compose or podman-compose when compose plugin absent

## Testing
- `./scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_688edd9bd1f883319a333bf86d96f1ea