### PR TITLE
fix: use COMPOSE_FILE for compose

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -66,7 +66,10 @@ fi
 echo "🔧  Using container runtime: $CTL"
 
 # ── Local side-car stack (room, tracker, regtest mint) ────────
-$COMPOSE -f infra/docker/docker-compose.dev.yml up -d
+# Some runtimes (across Docker and Podman variants) handle compose
+# file flags differently. Setting the COMPOSE_FILE environment
+# variable keeps the command compatible across implementations.
+COMPOSE_FILE=infra/docker/docker-compose.dev.yml $COMPOSE up -d
 
 # ── Node dependencies ─────────────────────────────────────────
 pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- use `COMPOSE_FILE` env var so compose works across Docker and Podman
- clarify comment about compose file flag differences

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688ee117f1788331bf9ab47e79f6f3bb