### PR TITLE
fix(dev): robust compose file flag detection

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -67,14 +67,18 @@ echo "🔧  Using container runtime: $CTL"
 
 # ── Local side-car stack (room, tracker, regtest mint) ────────
 # Some compose implementations only support either the short `-f` flag or
-# the long `--file` flag when selecting the compose file. Detect support and
-# fall back to the short flag if the long form is unavailable.
-if $COMPOSE --help 2>&1 | grep -q -- "--file"; then
+# the long `--file` flag when selecting the compose file. Try the long form
+# first and fall back to the short flag if necessary.
+COMPOSE_FILE=infra/docker/docker-compose.dev.yml
+if $COMPOSE --file "$COMPOSE_FILE" config >/dev/null 2>&1; then
   COMPOSE_FILE_FLAG="--file"
-else
+elif $COMPOSE -f "$COMPOSE_FILE" config >/dev/null 2>&1; then
   COMPOSE_FILE_FLAG="-f"
+else
+  echo "❌  Unable to determine compose file flag." >&2
+  exit 1
 fi
-$COMPOSE $COMPOSE_FILE_FLAG infra/docker/docker-compose.dev.yml up -d
+$COMPOSE $COMPOSE_FILE_FLAG "$COMPOSE_FILE" up -d
 
 # ── Node dependencies ─────────────────────────────────────────
 pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- try `--file` first then fall back to `-f` to select compose file in dev script

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688ee4d4a9708331bceaa26b509a7973