### PR TITLE
Add torrent seeder and DHT bridge to dev docker stack

### DIFF
--- a/infra/docker/docker-compose.dev.yml
+++ b/infra/docker/docker-compose.dev.yml
@@ -14,9 +14,34 @@ services:
     command: --ws --stats
     ports: [ "8000:8000" ]
 
+  wt-seeder:
+    image: node:20-alpine
+    volumes: [ "torrent-cache:/cache" ]
+    entrypoint: |
+      sh -c "npm i -g webtorrent-cli && while true; do sleep 3600; done"
+    restart: unless-stopped
+
+  dht-bridge:
+    image: anacrolix/dhttracker:latest   # UDP↔WebSocket
+    restart: unless-stopped
+    environment:
+      ADDR: ":6881"
+    networks: [internal]
+    healthcheck:
+      test: curl -f http://localhost:6881/debug || exit 1
+      interval: 30s
+      retries: 3
+
   cashu-mint:
     image: cashubtc/mintd:latest
     ports: [ "3333:3333" ]
     environment:
       MINT_HOST: "0.0.0.0"
       MINT_PRIVATE_KEY: "regtestkey"
+
+volumes:
+  torrent-cache:
+
+networks:
+  internal:
+    internal: true

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -71,7 +71,7 @@ if ! $CTL info >/dev/null 2>&1 && ! $COMPOSE version >/dev/null 2>&1; then
   exit 1
 fi
 
-# ── Local side-car stack (room, tracker, regtest mint) ────────
+# ── Local side-car stack (room, tracker, seeder, DHT bridge, regtest mint) ────────
 # Some compose implementations only support either the short `-f` flag or
 # the long `--file` flag when selecting the compose file. Inspect the help
 # output of `config` to determine which one is available without contacting


### PR DESCRIPTION
## Summary
- include wt-seeder and dht-bridge services in development docker-compose
- declare torrent-cache volume and internal network
- document new side-car services in dev script comment

## Testing
- `./scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_688ef742effc83318d54362f56b4d00f