### PR TITLE
feat(config): allow overriding DHT bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ To start the development stack manually:
 This boots supporting containers (room server, tracker and regtest mint), installs dependencies and runs the
 Vite development server for the web app.
 
+### Environment variables
+
+The development server recognises a few optional variables for overriding network endpoints:
+
+- `VITE_DHT_URL` – WebSocket URL of the DHT bootstrap node. Defaults to `ws://localhost:6881`.
+
 ## Running tests
 
 Unit tests can be run with the helper script:

--- a/packages/worker-torrent/src/index.ts
+++ b/packages/worker-torrent/src/index.ts
@@ -9,6 +9,7 @@ import { useSettings } from '../../shared/store/settings';
 import { createRPCHandler } from '../../shared/rpc';
 import { cache, touch, prune } from '../../worker-ssb/src/blobCache';
 import { getSSB } from '../../worker-ssb/src/instance';
+import { getDefaultEndpoints } from '../../shared/config';
 
 const require = createRequire(import.meta.url);
 let wrtc: any;
@@ -26,10 +27,11 @@ const { trackerUrls: trackers, rtcConfig } = useSettings.getState();
 const client = new WebTorrent({ tracker: { rtcConfig } });
 
 // ── DHT bridge  ─────────────────────────────────────────────
-const { enableDht, roomUrl } = useSettings.getState();
+const { enableDht } = useSettings.getState();
+const { dht: dhtUrl } = getDefaultEndpoints();
 let dht: any;
 if (enableDht && DHT) {
-  dht = new DHT({ wrtc, bootstrap: [`wss://dht.${new URL(roomUrl).hostname}`] });
+  dht = new DHT({ wrtc, bootstrap: [dhtUrl] });
   const timeout = setTimeout(() => {
     postMessage({ type: 'dht_unreachable' });
     dht.destroy();

--- a/shared/config.ts
+++ b/shared/config.ts
@@ -3,14 +3,16 @@ import { z } from 'zod';
 const envSchema = z.object({
   VITE_ROOM_URL: z.string().optional(),
   VITE_TRACKER_URLS: z.string().optional(), // JSON array string
+  VITE_DHT_URL: z.string().optional(),
 });
 const env = envSchema.parse(import.meta.env);
 
 /**
- * Returns default Room + Tracker URLs.
+ * Returns default Room, Tracker and DHT URLs.
  * 1. If app served from https://app.cashucast.app:
  *    • room → wss://room.cashucast.app
  *    • tracker → wss://tracker.cashucast.app
+ *    • dht → wss://dht.cashucast.app
  * 2. Else fall back to VITE_* values.
  */
 export function getDefaultEndpoints() {
@@ -20,6 +22,7 @@ export function getDefaultEndpoints() {
       trackerList: env.VITE_TRACKER_URLS
         ? JSON.parse(env.VITE_TRACKER_URLS)
         : ['ws://localhost:8000'],
+      dht: env.VITE_DHT_URL || 'ws://localhost:6881',
     };
   }
 
@@ -38,6 +41,8 @@ export function getDefaultEndpoints() {
       ? JSON.parse(env.VITE_TRACKER_URLS)
       : ['ws://localhost:8000'];
 
-  return { room, trackerList };
+  const dht = base ? `wss://dht.${base}` : env.VITE_DHT_URL || 'ws://localhost:6881';
+
+  return { room, trackerList, dht };
 }
 


### PR DESCRIPTION
## Summary
- allow specifying DHT bootstrap URL via `VITE_DHT_URL` with local fallback
- use configured DHT URL when bootstrapping worker-torrent
- document `VITE_DHT_URL` for development setups

## Testing
- `./scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_688ef9452fe88331888698b815daa4fd