### PR TITLE
chore: drop compose version

### DIFF
--- a/infra/docker/Caddyfile
+++ b/infra/docker/Caddyfile
@@ -1,16 +1,16 @@
-room.cashucast.app {
+{$ROOM_HOST} {
     reverse_proxy / ws://ssb-room:3000
     encode zstd gzip
     rate_limit * 20r/s
 }
 
-tracker.cashucast.app {
+{$TRACKER_HOST} {
     reverse_proxy / ws://wt-tracker:8000
     encode zstd gzip
     rate_limit * 40r/s
 }
 
-dht.cashucast.app {
+{$DHT_HOST} {
     reverse_proxy / ws://dht-bridge:6881
     encode zstd gzip
     rate_limit * 30r/s

--- a/infra/docker/docker-compose.dev.yml
+++ b/infra/docker/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   ssb-room:
     image: ssbc/ssb-room2:latest

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   ssb-room:
     image: ssbc/ssb-room2:latest
@@ -7,11 +5,11 @@ services:
     environment:
       ROOM_PUBLISH: "true"
       ROOM_NAME: "CashuCast Room"
-      ROOM_HOST: "room.cashucast.app"
+      ROOM_HOST: "${ROOM_HOST}"
 
   wt-tracker:
     image: nickert/webtorrent-tracker:latest
-    command: --ws --stats --whitelist "cashucast.app"
+    command: --ws --stats --whitelist ${APP_DOMAIN}
     restart: unless-stopped
 
   wt-seeder:


### PR DESCRIPTION
## Summary
- remove `version` field from dev and prod Docker Compose configs
- make Docker hostnames configurable instead of hard-coding cashucast.app

## Testing
- `docker-compose -f infra/docker/docker-compose.dev.yml config | tail -n 20`
- `ROOM_HOST=room.example.com APP_DOMAIN=example.com docker-compose -f infra/docker/docker-compose.prod.yml config | tail -n 20`
- `ROOM_HOST=room.example.com APP_DOMAIN=example.com docker-compose -f infra/docker/docker-compose.prod.yml config | grep ROOM_HOST`


------
https://chatgpt.com/codex/tasks/task_e_688efa778340833190a1a2d652953e2a