### PR TITLE
Fix webtorrent tracker command in compose files

### DIFF
--- a/infra/docker/docker-compose.dev.yml
+++ b/infra/docker/docker-compose.dev.yml
@@ -10,7 +10,12 @@ services:
 
   wt-tracker:
     image: nickert/webtorrent-tracker:latest
-    command: --ws --stats --whitelist "localhost"
+    command:
+      - webtorrent-tracker
+      - --ws
+      - --stats
+      - --whitelist
+      - localhost
     restart: unless-stopped
     ports: [ "8000:8000" ]
 

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -9,7 +9,12 @@ services:
 
   wt-tracker:
     image: nickert/webtorrent-tracker:latest
-    command: --ws --stats --whitelist ${APP_DOMAIN}
+    command:
+      - webtorrent-tracker
+      - --ws
+      - --stats
+      - --whitelist
+      - cashucast.app
     restart: unless-stopped
 
   wt-seeder:


### PR DESCRIPTION
## Summary
- explicitly call `webtorrent-tracker` in wt-tracker command
- whitelist `localhost` for dev and `cashucast.app` for prod

## Testing
- `pnpm test`
- `docker-compose -f infra/docker/docker-compose.dev.yml up -d wt-tracker` *(fails: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_688efc7ec7f48331a7a7fa44d4f2b287