### PR TITLE
Use public webtorrent tracker image in dev compose

### DIFF
--- a/infra/docker/docker-compose.dev.yml
+++ b/infra/docker/docker-compose.dev.yml
@@ -9,7 +9,7 @@ services:
       ROOM_HOST: "localhost"
 
   wt-tracker:
-    image: nickert/webtorrent-tracker:latest
+    image: webtorrent/webtorrent-tracker:latest
     command:
       - webtorrent-tracker
       - --ws


### PR DESCRIPTION
## Summary
- replace `wt-tracker` dev image with public `webtorrent/webtorrent-tracker`

## Testing
- `pnpm test`
- `docker-compose -f infra/docker/docker-compose.dev.yml up wt-tracker` *(fails: ConnectionRefusedError: [Errno 111] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688eff7ada6c83318e545ae1cc7e1ac0