### PR TITLE
Use webtorrent-hybrid image for dev tracker

### DIFF
--- a/infra/docker/docker-compose.dev.yml
+++ b/infra/docker/docker-compose.dev.yml
@@ -9,13 +9,8 @@ services:
       ROOM_HOST: "localhost"
 
   wt-tracker:
-    image: webtorrent/webtorrent-tracker:latest
-    command:
-      - webtorrent-tracker
-      - --ws
-      - --stats
-      - --whitelist
-      - localhost
+    image: schaurian/webtorrent-hybrid:5.0.2
+    command: ["sh", "-c", "npm i -g webtorrent-tracker && webtorrent-tracker --ws --stats --whitelist localhost"]
     restart: unless-stopped
     ports: [ "8000:8000" ]
 


### PR DESCRIPTION
## Summary
- fix dev docker compose webtorrent tracker image by using schaurian/webtorrent-hybrid and installing tracker at start

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688f02235e2883319738102347f4a221