### PR TITLE
chore: run web app without pnpm workspace

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -96,4 +96,5 @@ $COMPOSE $COMPOSE_FILE_FLAG "$COMPOSE_FILE" up -d
 pnpm install --frozen-lockfile
 
 # ── Run the web app with hot reload ───────────────────────────
-pnpm --filter apps/web dev
+cd apps/web
+pnpm dev


### PR DESCRIPTION
## Summary
- adjust dev script to run web app via `pnpm dev` instead of workspace filter

## Testing
- `pnpm install --frozen-lockfile`
- `(cd apps/web && pnpm dev)`

------
https://chatgpt.com/codex/tasks/task_e_688f08c48e148331827a7bd54b553af0