### PR TITLE
docs: note container permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Bootstrap a fresh Linux machine with all dependencies by running:
 ```
 
 The script installs Node.js 20, pnpm and a container engine (Docker or Podman) before running
-`pnpm install --frozen-lockfile`.
+`pnpm install --frozen-lockfile`.  Depending on your system, container commands may require root
+privileges or membership in the engine's group.  If you encounter permission errors, run the
+commands with `sudo` or add your user to the appropriate group.
 
 If you prefer to install the prerequisites manually, run the following commands on a fresh
 Linux machine:

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -5,6 +5,18 @@ set -e
 command -v pnpm >/dev/null || {
   echo "❌  pnpm not found. Install it first."; exit 1; }
 
+# ── Permission checks for container engines ───────────────────
+for bin in docker podman; do
+  if command -v "$bin" >/dev/null 2>&1; then
+    if ! out=$($bin info 2>&1); then
+      if echo "$out" | grep -qi 'permission denied'; then
+        echo "❌  Cannot access $bin daemon. Run this script with sudo or add your user to the $bin group." >&2
+        exit 1
+      fi
+    fi
+  fi
+done
+
 # ── Detect runtimes & health ──────────────────────────────────
 check_runtime() {
   local bin=$1


### PR DESCRIPTION
## Summary
- document that container commands may need root or group membership
- detect container runtime permission errors in dev helper script

## Testing
- `./scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_688f0cc5aad48331b168cba580ba2e09