### PR TITLE
fix: correct shared module paths

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ROUTES } from './router';
-import { useProfile } from '../../shared/store/profile';
+import { useProfile } from '../shared/store/profile';
 import Onboarding from './routes/Onboarding';
 import SearchBar from './components/SearchBar';
 

--- a/apps/web/src/bootStatsWorker.ts
+++ b/apps/web/src/bootStatsWorker.ts
@@ -1,6 +1,9 @@
 import { useSettings } from '../shared/store/settings';
 export const statsWorker = (() => {
-  const w = new Worker(new URL('../../packages/stats-worker/index.ts', import.meta.url), { type:'module' });
+  const w = new Worker(
+    new URL('../../../packages/stats-worker/index.ts', import.meta.url),
+    { type: 'module' }
+  );
   w.postMessage({ tracker: useSettings.getState().trackerUrls[0] });
   return w;
 })();

--- a/apps/web/src/components/FilterBar.tsx
+++ b/apps/web/src/components/FilterBar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import TagInput from './TagInput';
-import { useFilters } from '../../../shared/store/filters';
+import { useFilters } from '../../shared/store/filters';
 
 export default function FilterBar() {
   const tags = useFilters((s) => s.tags);

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useRef } from 'react';
 import { Search } from 'lucide-react';
-import { createRPCClient } from '../../../shared/rpc';
-import { useSearch } from '../../../shared/store/search';
-import type { Post } from '../../../shared/types';
+import { createRPCClient } from '../../shared/rpc';
+import { useSearch } from '../../shared/store/search';
+import type { Post } from '../../shared/types';
 
 export default function SearchBar() {
   const { open, q, setOpen, setQ, setResults } = useSearch();

--- a/apps/web/src/components/TimelineCard.tsx
+++ b/apps/web/src/components/TimelineCard.tsx
@@ -7,11 +7,11 @@ import {
   Avatar,
   BottomSheet,
   Profile,
-} from '../../../shared/ui';
+} from '../../shared/ui';
 import { CommentsDrawer } from './CommentsDrawer';
 import ActionColumn from './ActionColumn';
 import { motion } from 'framer-motion';
-import { createRPCClient } from '../../../shared/rpc';
+import { createRPCClient } from '../../shared/rpc';
 
 export interface TimelineCardProps {
   /** URL for the author's avatar */

--- a/apps/web/src/routes/Discover.tsx
+++ b/apps/web/src/routes/Discover.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { createRPCClient } from '../../../shared/rpc';
-import type { Post } from '../../../shared/types';
-import { useSearch } from '../../../shared/store/search';
+import { createRPCClient } from '../../shared/rpc';
+import type { Post } from '../../shared/types';
+import { useSearch } from '../../shared/store/search';
 import { TimelineCard } from '../components/TimelineCard';
 
 interface TagCount { tag: string; count: number }

--- a/apps/web/src/routes/Onboarding.test.tsx
+++ b/apps/web/src/routes/Onboarding.test.tsx
@@ -10,7 +10,7 @@ vi.mock('../../shared/rpc', () => ({
 }));
 
 import Onboarding from './Onboarding';
-import { useProfile } from '../../../../shared/store/profile';
+import { useProfile } from '../../shared/store/profile';
 
 class MockWorker {
   onmessage: ((e: any) => void) | null = null;

--- a/apps/web/src/routes/SearchResults.tsx
+++ b/apps/web/src/routes/SearchResults.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TimelineCard } from '../components/TimelineCard';
-import { useSearch } from '../../../shared/store/search';
+import { useSearch } from '../../shared/store/search';
 
 export default function SearchResults() {
   const results = useSearch((s) => s.results);

--- a/apps/web/src/routes/SettingsStorage.tsx
+++ b/apps/web/src/routes/SettingsStorage.tsx
@@ -1,5 +1,5 @@
 import { useSettings } from '../../shared/store/settings';
-import { setMaxCacheMB } from '../../../packages/worker-ssb/src/blobCache';
+import { setMaxCacheMB } from '../../../../packages/worker-ssb/src/blobCache';
 
 export const SettingsStorage: React.FC = () => {
   const { maxBlobMB, setMaxBlobMB } = useSettings();

--- a/packages/integration/__tests__/flow.test.ts
+++ b/packages/integration/__tests__/flow.test.ts
@@ -39,7 +39,7 @@ vi.mock('../../worker-ssb/src/blobCache', () => ({
   touch: vi.fn(),
   prune: vi.fn(),
 }));
-vi.mock('../../shared/store/settings', () => ({
+vi.mock('../../../shared/store/settings', () => ({
   useSettings: { getState: () => ({ trackerUrls: [] }) },
 }));
 

--- a/packages/worker-torrent/__tests__/torrent.test.ts
+++ b/packages/worker-torrent/__tests__/torrent.test.ts
@@ -39,7 +39,7 @@ vi.mock('../../worker-ssb/src/blobCache', () => ({
   touch: vi.fn(),
   prune: vi.fn(),
 }));
-vi.mock('../../shared/store/settings', () => ({
+vi.mock('../../../shared/store/settings', () => ({
   useSettings: { getState: () => ({ trackerUrls: [] }) },
 }));
 


### PR DESCRIPTION
## Summary
- fix import paths across web app to use local `shared` symlink
- correct worker package paths including stats and blob cache imports
- adjust tests to mock settings using new shared path

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688f0f30ca608331900903a22ad981fe