### PR TITLE
feat: add video recording route

### DIFF
--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -4,9 +4,11 @@ import Compose from './routes/Compose';
 import SettingsOverlay from './routes/SettingsOverlay';
 import SearchResults from './routes/SearchResults';
 import Discover from './routes/Discover';
+import Record from './routes/Record';
 
 export const ROUTES: Record<string, React.FC> = {
   '/compose': Compose,
+  '/record': Record,
   '/settings': SettingsOverlay,
   '/search': SearchResults,
   '/discover': Discover,

--- a/apps/web/src/routes/Record.tsx
+++ b/apps/web/src/routes/Record.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { VideoRecorder } from '../../shared/ui';
+
+declare global {
+  interface Window {
+    recordedFile?: File;
+  }
+}
+
+const Record: React.FC = () => {
+  const handleComplete = (blob: Blob) => {
+    if (typeof window !== 'undefined') {
+      window.recordedFile = new File([blob], 'recording.webm', {
+        type: 'video/webm',
+      });
+      window.history.pushState(null, '', '/compose');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <VideoRecorder onComplete={handleComplete} />
+    </div>
+  );
+};
+
+export default Record;
+

--- a/shared/ui/FabRecord.tsx
+++ b/shared/ui/FabRecord.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
-declare const navigate: (path: string) => void;
-
 const FabRecord: React.FC = () => {
   const handleClick = () => {
-    navigate('/record');
+    if (typeof window !== 'undefined') {
+      window.history.pushState(null, '', '/record');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    }
   };
 
   return (

--- a/shared/ui/VideoRecorder.tsx
+++ b/shared/ui/VideoRecorder.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+export interface VideoRecorderProps {
+  /** Called when recording completes with the recorded blob */
+  onComplete: (blob: Blob) => void;
+}
+
+/**
+ * VideoRecorder accesses the user's webcam and microphone to record video.
+ * Recording automatically stops after 300000ms (5 minutes) and the collected
+ * blob is passed to the onComplete callback.
+ */
+const VideoRecorder: React.FC<VideoRecorderProps> = ({ onComplete }) => {
+  const videoRef = React.useRef<HTMLVideoElement>(null);
+
+  React.useEffect(() => {
+    let stream: MediaStream | null = null;
+    let recorder: MediaRecorder | null = null;
+    const chunks: BlobPart[] = [];
+    let timeout: number;
+
+    const start = async () => {
+      try {
+        if (!navigator.mediaDevices?.getUserMedia) {
+          throw new Error('media devices not supported');
+        }
+        stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+        }
+        recorder = new MediaRecorder(stream, { mimeType: 'video/webm' });
+        recorder.ondataavailable = (e) => {
+          if (e.data.size > 0) chunks.push(e.data);
+        };
+        recorder.onstop = () => {
+          const blob = new Blob(chunks, { type: 'video/webm' });
+          onComplete(blob);
+        };
+        recorder.start();
+        timeout = window.setTimeout(() => {
+          if (recorder && recorder.state === 'recording') {
+            recorder.stop();
+          }
+        }, 300000);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
+    start();
+
+    return () => {
+      clearTimeout(timeout);
+      if (recorder && recorder.state === 'recording') recorder.stop();
+      stream?.getTracks().forEach((t) => t.stop());
+    };
+  }, [onComplete]);
+
+  return <video ref={videoRef} autoPlay playsInline className="w-full" />;
+};
+
+export default VideoRecorder;
+

--- a/shared/ui/index.ts
+++ b/shared/ui/index.ts
@@ -37,3 +37,4 @@ export * from './BackupSeedBtn';
 export * from './Settings';
 export * from './PostMenu';
 export { default as FabRecord } from './FabRecord';
+export { default as VideoRecorder } from './VideoRecorder';


### PR DESCRIPTION
## Summary
- add `VideoRecorder` component using MediaRecorder with automatic 5‑minute stop
- implement `/record` route that records video and redirects back to compose
- wire `/record` into router and floating action button navigation

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688f142fd55483319414d59dfe5a6628