### PR TITLE
fix: avoid node module in browser workers

### DIFF
--- a/packages/worker-ssb/src/instance.ts
+++ b/packages/worker-ssb/src/instance.ts
@@ -1,18 +1,16 @@
 import { useSettings } from '../../../shared/store/settings';
-import { createRequire } from 'module';
-
-const require = createRequire(import.meta.url);
+import net from 'ssb-browser-core/net';
+import ssbBlobs from 'ssb-blobs';
 
 let ssb: any = (globalThis as any).__cashuSSB;
 
 export function getSSB() {
   if (ssb) return ssb;
 
-  const net = require('ssb-browser-core/net');
   const { roomUrl } = useSettings.getState();
 
   ssb = net.init('cashucast-ssb', {}, (stack: any) =>
-    stack.use(require('ssb-blobs'))
+    stack.use(ssbBlobs)
   );
 
   if (roomUrl) {


### PR DESCRIPTION
## Summary
- import SSB and blob modules directly instead of using `createRequire`
- dynamically load optional DHT/wrtc dependencies for torrent worker

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688f1a37112083319c42bfb53535d1b6