### PR TITLE
chore: exclude ssb packages from Vite optimizeDeps

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  optimizeDeps: {
+    exclude: ['ssb-blobs', 'ssb-browser-core/net'],
+  },
+});


### PR DESCRIPTION
## Summary
- add Vite config for web app
- avoid pre-bundling ssb-blobs and ssb-browser-core/net

## Testing
- `pnpm --filter web dev`
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688f1e8cc69883319946ec870a2f6266