### PR TITLE
fix: use named import for ssb net

### DIFF
--- a/packages/worker-ssb/src/instance.ts
+++ b/packages/worker-ssb/src/instance.ts
@@ -1,5 +1,5 @@
 import { useSettings } from '../../../shared/store/settings';
-import net from 'ssb-browser-core/net';
+import { init as ssbInit } from 'ssb-browser-core/net';
 import ssbBlobs from 'ssb-blobs';
 
 let ssb: any = (globalThis as any).__cashuSSB;
@@ -9,7 +9,7 @@ export function getSSB() {
 
   const { roomUrl } = useSettings.getState();
 
-  ssb = net.init('cashucast-ssb', {}, (stack: any) =>
+  ssb = ssbInit('cashucast-ssb', {}, (stack: any) =>
     stack.use(ssbBlobs)
   );
 


### PR DESCRIPTION
## Summary
- import ssb-browser-core/net using its named `init` export to avoid runtime error

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688f20f0220483319c391ca68743ee08