### PR TITLE
fix: handle ssb-blobs without default export

### DIFF
--- a/packages/worker-ssb/src/instance.ts
+++ b/packages/worker-ssb/src/instance.ts
@@ -1,6 +1,6 @@
 import { useSettings } from '../../../shared/store/settings';
 import { init as ssbInit } from 'ssb-browser-core/net';
-import ssbBlobs from 'ssb-blobs';
+import * as ssbBlobs from 'ssb-blobs';
 
 let ssb: any = (globalThis as any).__cashuSSB;
 


### PR DESCRIPTION
## Summary
- import `ssb-blobs` as a namespace so `stack.use` receives the plugin

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688f2221bbe083318d3449dfb554f843