### PR TITLE
Fix ssb-browser-core import to avoid runtime error

### DIFF
--- a/packages/worker-ssb/src/instance.ts
+++ b/packages/worker-ssb/src/instance.ts
@@ -1,5 +1,5 @@
 import { useSettings } from '../../../shared/store/settings';
-import { init as ssbInit } from 'ssb-browser-core/net';
+import * as ssbNet from 'ssb-browser-core/net';
 import * as ssbBlobs from 'ssb-blobs';
 
 let ssb: any = (globalThis as any).__cashuSSB;
@@ -9,7 +9,7 @@ export function getSSB() {
 
   const { roomUrl } = useSettings.getState();
 
-  ssb = ssbInit('cashucast-ssb', {}, (stack: any) =>
+  ssb = ssbNet.init('cashucast-ssb', {}, (stack: any) =>
     stack.use(ssbBlobs)
   );
 


### PR DESCRIPTION
## Summary
- fix ssb-browser-core net import by using namespace import and calling init

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688f2376ca1483319ee1f35da7f39e1f