### PR TITLE
fix: allow ssb-browser-core bundling

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,6 +4,6 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   optimizeDeps: {
-    exclude: ['ssb-blobs', 'ssb-browser-core/net'],
+    exclude: ['ssb-blobs'],
   },
 });


### PR DESCRIPTION
## Summary
- remove ssb-browser-core/net from Vite dependency exclusion so it is prebundled

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688f257bb2088331af7f73c54ea6a61a