### PR TITLE
fix: handle ssb reserved words in test configs

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,45 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-
-/**
- * Some SSB dependencies published as CommonJS use identifiers such as
- * `private` and `public` for local variables. While that is valid in sloppy
- * mode, esbuild (used by Vite) parses dependencies in strict mode when
- * outputting ESM and fails on those identifiers.  We workaround this without
- * patching the dependencies by transforming the affected files on the fly and
- * renaming the problematic identifiers.
- */
-function ssbReservedWordsFix() {
-  return {
-    name: 'ssb-reserved-words-fix',
-    enforce: 'pre',
-    transform(code: string, id: string) {
-      if (id.includes('ssb-subset-ql/ql0.js')) {
-        let transformed = code.replace(
-          'const { author, type, private } = query',
-          'const { author, type, private: isPrivate } = query',
-        );
-        transformed = transformed.replace(
-          /"private":\$\{private\}/g,
-          '"private":${isPrivate}',
-        );
-        return { code: transformed, map: null };
-      }
-      if (id.includes('ssb-bendy-butt/validation.js')) {
-        let transformed = code.replace(
-          "const public = authorBFE.subarray(2).toString('base64') + '.ed25519'",
-          "const publicKey = authorBFE.subarray(2).toString('base64') + '.ed25519'",
-        );
-        transformed = transformed.replace(
-          "const keys = { public, curve: 'ed25519' }",
-          "const keys = { public: publicKey, curve: 'ed25519' }",
-        );
-        return { code: transformed, map: null };
-      }
-      return null;
-    },
-  };
-}
+import ssbReservedWordsFix from '../../ssb-reserved-words-fix';
 
 export default defineConfig({
   plugins: [ssbReservedWordsFix(), react()],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,12 @@
 import { defineConfig } from '@playwright/experimental-ct-react';
 import react from '@vitejs/plugin-react';
+import ssbReservedWordsFix from './ssb-reserved-words-fix';
 
 export default defineConfig({
   testDir: './apps/web/playwright',
   testMatch: /.*\.pw\.tsx/,
   ctViteConfig: {
-    plugins: [react()],
+    plugins: [ssbReservedWordsFix(), react()],
   },
 });
 

--- a/ssb-reserved-words-fix.ts
+++ b/ssb-reserved-words-fix.ts
@@ -1,0 +1,31 @@
+export default function ssbReservedWordsFix() {
+  return {
+    name: 'ssb-reserved-words-fix',
+    enforce: 'pre',
+    transform(code: string, id: string) {
+      if (id.includes('ssb-subset-ql/ql0.js')) {
+        let transformed = code.replace(
+          'const { author, type, private } = query',
+          'const { author, type, private: isPrivate } = query',
+        );
+        transformed = transformed.replace(
+          /"private":\$\{private\}/g,
+          '"private":${isPrivate}',
+        );
+        return { code: transformed, map: null };
+      }
+      if (id.includes('ssb-bendy-butt/validation.js')) {
+        let transformed = code.replace(
+          "const public = authorBFE.subarray(2).toString('base64') + '.ed25519'",
+          "const publicKey = authorBFE.subarray(2).toString('base64') + '.ed25519'",
+        );
+        transformed = transformed.replace(
+          "const keys = { public, curve: 'ed25519' }",
+          "const keys = { public: publicKey, curve: 'ed25519' }",
+        );
+        return { code: transformed, map: null };
+      }
+      return null;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared Vite transform to rewrite reserved `private` and `public` identifiers in SSB deps
- use the transform in Vite and Playwright configs to avoid strict‑mode errors

## Testing
- `pnpm test`
- `pnpm exec playwright test` *(fails: browsers missing, run `pnpm exec playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_688f289f423c8331b1f0de7f073bef3a