### PR TITLE
fix: patch reserved words for vite build

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,10 +1,15 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import ssbReservedWordsFix from '../../ssb-reserved-words-fix';
+import ssbReservedWordsFix, {
+  ssbReservedWordsFixEsbuild,
+} from '../../ssb-reserved-words-fix';
 
 export default defineConfig({
   plugins: [ssbReservedWordsFix(), react()],
   optimizeDeps: {
     exclude: ['ssb-blobs'],
+    esbuildOptions: {
+      plugins: [ssbReservedWordsFixEsbuild()],
+    },
   },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,12 +1,19 @@
 import { defineConfig } from '@playwright/experimental-ct-react';
 import react from '@vitejs/plugin-react';
-import ssbReservedWordsFix from './ssb-reserved-words-fix';
+import ssbReservedWordsFix, {
+  ssbReservedWordsFixEsbuild,
+} from './ssb-reserved-words-fix';
 
 export default defineConfig({
   testDir: './apps/web/playwright',
   testMatch: /.*\.pw\.tsx/,
   ctViteConfig: {
     plugins: [ssbReservedWordsFix(), react()],
+    optimizeDeps: {
+      esbuildOptions: {
+        plugins: [ssbReservedWordsFixEsbuild()],
+      },
+    },
   },
 });
 

--- a/ssb-reserved-words-fix.ts
+++ b/ssb-reserved-words-fix.ts
@@ -1,4 +1,8 @@
-export default function ssbReservedWordsFix() {
+import type { Plugin as VitePlugin } from 'vite';
+import type { Plugin as EsbuildPlugin } from 'esbuild';
+import { readFile } from 'fs/promises';
+
+export default function ssbReservedWordsFix(): VitePlugin {
   return {
     name: 'ssb-reserved-words-fix',
     enforce: 'pre',
@@ -26,6 +30,38 @@ export default function ssbReservedWordsFix() {
         return { code: transformed, map: null };
       }
       return null;
+    },
+  };
+}
+
+export function ssbReservedWordsFixEsbuild(): EsbuildPlugin {
+  return {
+    name: 'ssb-reserved-words-fix-esbuild',
+    setup(build) {
+      build.onLoad({ filter: /ssb-subset-ql\/ql0\.js$/ }, async (args) => {
+        let code = await readFile(args.path, 'utf8');
+        code = code
+          .replace(
+            'const { author, type, private } = query',
+            'const { author, type, private: isPrivate } = query',
+          )
+          .replace(/"private":\$\{private\}/g, '"private":${isPrivate}');
+        return { contents: code, loader: 'js' };
+      });
+
+      build.onLoad({ filter: /ssb-bendy-butt\/validation\.js$/ }, async (args) => {
+        let code = await readFile(args.path, 'utf8');
+        code = code
+          .replace(
+            "const public = authorBFE.subarray(2).toString('base64') + '.ed25519'",
+            "const publicKey = authorBFE.subarray(2).toString('base64') + '.ed25519'",
+          )
+          .replace(
+            "const keys = { public, curve: 'ed25519' }",
+            "const keys = { public: publicKey, curve: 'ed25519' }",
+          );
+        return { contents: code, loader: 'js' };
+      });
     },
   };
 }


### PR DESCRIPTION
## Summary
- export esbuild version of reserved words fix plugin
- apply plugin during dependency pre-bundling for web app and playwright CT config

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688f2a1a55b08331a5f39cb4283ffcb9