### PR TITLE
fix: polyfill buffer early

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,10 +1,14 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { Buffer } from "buffer";
-import App from "./App";
 
+// Ensure Node-style Buffer is available before loading the rest of the app.
 globalThis.Buffer = globalThis.Buffer || Buffer;
 
 const container = document.getElementById("root")!;
 const root = createRoot(container);
-root.render(<React.StrictMode><App /></React.StrictMode>);
+
+// Dynamically import the application only after Buffer has been polyfilled.
+import("./App").then(({ default: App }) => {
+  root.render(<React.StrictMode><App /></React.StrictMode>);
+});


### PR DESCRIPTION
## Summary
- polyfill Buffer before loading the app to avoid ReferenceError in browser

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688f3282f1f88331b04de9bfed593cd4