### PR TITLE
fix: polyfill Buffer for browser

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,14 +1,19 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
-import { Buffer } from "buffer";
 
-// Ensure Node-style Buffer is available before loading the rest of the app.
-globalThis.Buffer = globalThis.Buffer || Buffer;
+async function bootstrap() {
+  // Polyfill Node's `Buffer` globally when running in the browser. Vite
+  // externalizes built-in modules, so we dynamically load the `buffer`
+  // package's implementation instead.
+  if (!globalThis.Buffer) {
+    const { Buffer } = await import("buffer/");
+    (globalThis as any).Buffer = Buffer;
+  }
 
-const container = document.getElementById("root")!;
-const root = createRoot(container);
-
-// Dynamically import the application only after Buffer has been polyfilled.
-import("./App").then(({ default: App }) => {
+  const container = document.getElementById("root")!;
+  const root = createRoot(container);
+  const { default: App } = await import("./App");
   root.render(<React.StrictMode><App /></React.StrictMode>);
-});
+}
+
+bootstrap();

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@yaireo/tagify": "^4.35.3",
     "bip39": "^3.1.0",
     "bittorrent-dht": "^11.0.10",
+    "buffer": "^6.0.3",
     "canvas-confetti": "^1.9.3",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.536.0",

--- a/packages/worker-ssb/index.ts
+++ b/packages/worker-ssb/index.ts
@@ -3,7 +3,6 @@
  * search. Exposes an RPC API used by the application to publish and query
  * posts without blocking the main thread.
  */
-import { Buffer } from 'buffer';
 import { createRPCHandler } from '../../shared/rpc';
 import type { Post } from '../../shared/types';
 import MiniSearch from 'minisearch';
@@ -14,7 +13,10 @@ import { get as getHistory } from '../../shared/store/history-worker';
 // worker is bundled for the browser the global `Buffer` does not exist yet and
 // those modules throw a `ReferenceError`. To avoid that we polyfill `Buffer`
 // before dynamically importing modules that rely on it.
-globalThis.Buffer = globalThis.Buffer || Buffer;
+if (!globalThis.Buffer) {
+  const { Buffer } = await import('buffer/');
+  (globalThis as any).Buffer = Buffer;
+}
 
 // Dynamic import ensures `Buffer` is available before evaluating modules that
 // depend on it (e.g. `ssb-browser-core`).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       bittorrent-dht:
         specifier: ^11.0.10
         version: 11.0.10
+      buffer:
+        specifier: ^6.0.3
+        version: 6.0.3
       canvas-confetti:
         specifier: ^1.9.3
         version: 1.9.3


### PR DESCRIPTION
## Summary
- dynamically import Buffer polyfill to avoid Vite externalization errors
- ensure worker and app bootstrap load Buffer before other modules
- add buffer dependency

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688f346745c88331aaa00e621645a89d