### PR TITLE
fix: stub Node fs for browser

### DIFF
--- a/apps/web/fs-shim.ts
+++ b/apps/web/fs-shim.ts
@@ -1,0 +1,5 @@
+export const readFile = undefined;
+export const readFileSync = undefined;
+export const writeFile = undefined;
+export const writeFileSync = undefined;
+export default { readFile, readFileSync, writeFile, writeFileSync };

--- a/apps/web/path-shim.ts
+++ b/apps/web/path-shim.ts
@@ -1,0 +1,2 @@
+export const join = (...parts: string[]) => parts.join('/');
+export default { join };

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,9 +3,16 @@ import react from '@vitejs/plugin-react';
 import ssbReservedWordsFix, {
   ssbReservedWordsFixEsbuild,
 } from '../../ssb-reserved-words-fix';
+import { resolve } from 'path';
 
 export default defineConfig({
   plugins: [ssbReservedWordsFix(), react()],
+  resolve: {
+    alias: {
+      fs: resolve(__dirname, 'fs-shim.ts'),
+      path: resolve(__dirname, 'path-shim.ts'),
+    },
+  },
   optimizeDeps: {
     exclude: ['ssb-blobs'],
     esbuildOptions: {


### PR DESCRIPTION
## Summary
- alias `fs` and `path` to lightweight shims in Vite config to prevent browser runtime errors
- add minimal `fs` and `path` shims

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f36a55b908331aaf7df0452ea54a4