### PR TITLE
fix: patch ssb-browser-core for browser

### DIFF
--- a/ssb-reserved-words-fix.ts
+++ b/ssb-reserved-words-fix.ts
@@ -29,6 +29,28 @@ export default function ssbReservedWordsFix(): VitePlugin {
         );
         return { code: transformed, map: null };
       }
+      if (id.includes('ssb-browser-core/net.js')) {
+        let transformed = code
+          .replace("const SecretStack = require('secret-stack')", "import SecretStack from 'secret-stack';")
+          .replace("const caps = require('ssb-caps')", "import caps from 'ssb-caps';")
+          .replace("const ssbKeys = require('ssb-keys')", "import ssbKeys from 'ssb-keys';")
+          .replace("const helpers = require('./core-helpers')", "import helpers from './core-helpers';")
+          .replace("const path = require('path')", "import path from 'path';")
+          .replace('exports.init = function', 'export function init');
+        return { code: transformed, map: null };
+      }
+      if (id.includes('ssb-browser-core/dist/bundle-core.js')) {
+        let transformed = code
+          .replace(
+            'persistentStorage=navigator.persistentStorage||navigator.webkitPersistentStorage',
+            'persistentStorage=navigator.storage',
+          )
+          .replace(
+            'function requestQuota(t,e,r){if("function"==typeof e)return requestQuota(t,!0,e);persistentStorage.queryUsageAndQuota(function(i,n){if(n&&!e)return r(null,n);persistentStorage.requestQuota(t,function(t){r(null,t)},r)},r)}',
+            'async function requestQuota(t,e,r){try{if("function"==typeof e)return requestQuota(t,!0,e);const n=persistentStorage.persist?await persistentStorage.persist():false;const i=await persistentStorage.estimate();r(null,i.quota);}catch(i){r(i);}}',
+          );
+        return { code: transformed, map: null };
+      }
       return null;
     },
   };
@@ -59,6 +81,32 @@ export function ssbReservedWordsFixEsbuild(): EsbuildPlugin {
           .replace(
             "const keys = { public, curve: 'ed25519' }",
             "const keys = { public: publicKey, curve: 'ed25519' }",
+          );
+        return { contents: code, loader: 'js' };
+      });
+
+      build.onLoad({ filter: /ssb-browser-core\/net\.js$/ }, async (args) => {
+        let code = await readFile(args.path, 'utf8');
+        code = code
+          .replace("const SecretStack = require('secret-stack')", "import SecretStack from 'secret-stack';")
+          .replace("const caps = require('ssb-caps')", "import caps from 'ssb-caps';")
+          .replace("const ssbKeys = require('ssb-keys')", "import ssbKeys from 'ssb-keys';")
+          .replace("const helpers = require('./core-helpers')", "import helpers from './core-helpers';")
+          .replace("const path = require('path')", "import path from 'path';")
+          .replace('exports.init = function', 'export function init');
+        return { contents: code, loader: 'js' };
+      });
+
+      build.onLoad({ filter: /ssb-browser-core\/dist\/bundle-core\.js$/ }, async (args) => {
+        let code = await readFile(args.path, 'utf8');
+        code = code
+          .replace(
+            'persistentStorage=navigator.persistentStorage||navigator.webkitPersistentStorage',
+            'persistentStorage=navigator.storage',
+          )
+          .replace(
+            'function requestQuota(t,e,r){if("function"==typeof e)return requestQuota(t,!0,e);persistentStorage.queryUsageAndQuota(function(i,n){if(n&&!e)return r(null,n);persistentStorage.requestQuota(t,function(t){r(null,t)},r)},r)}',
+            'async function requestQuota(t,e,r){try{if("function"==typeof e)return requestQuota(t,!0,e);const n=persistentStorage.persist?await persistentStorage.persist():false;const i=await persistentStorage.estimate();r(null,i.quota);}catch(i){r(i);}}',
           );
         return { contents: code, loader: 'js' };
       });


### PR DESCRIPTION
## Summary
- patch ssb-browser-core to use navigator.storage instead of deprecated persistentStorage
- convert ssb-browser-core net.js to ES modules so bundler can alias `path`

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688f3846322c8331a7e95667c895afc1