### PR TITLE
fix: import ssb-browser-core with named export

### DIFF
--- a/packages/ambient.d.ts
+++ b/packages/ambient.d.ts
@@ -1,4 +1,10 @@
-declare module 'ssb-browser-core/net';
+declare module 'ssb-browser-core/net' {
+  export function init(
+    dir: string,
+    overwriteConfig?: any,
+    extraModules?: any,
+  ): any;
+}
 declare module 'ssb-blobs';
 declare module 'webtorrent';
 declare module 'bittorrent-dht';

--- a/packages/worker-ssb/src/instance.ts
+++ b/packages/worker-ssb/src/instance.ts
@@ -1,5 +1,5 @@
 import { useSettings } from '../../../shared/store/settings';
-import * as ssbNet from 'ssb-browser-core/net';
+import { init as initSSB } from 'ssb-browser-core/net';
 import * as ssbBlobs from 'ssb-blobs';
 
 let ssb: any = (globalThis as any).__cashuSSB;
@@ -9,9 +9,7 @@ export function getSSB() {
 
   const { roomUrl } = useSettings.getState();
 
-  ssb = ssbNet.init('cashucast-ssb', {}, (stack: any) =>
-    stack.use(ssbBlobs)
-  );
+  ssb = initSSB('cashucast-ssb', {}, (stack: any) => stack.use(ssbBlobs));
 
   if (roomUrl) {
     try {


### PR DESCRIPTION
## Summary
- fix worker SSB initialization by importing ssb-browser-core/net via its named `init` export
- declare `init` in ambient types for ssb-browser-core/net

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688f3a1c1b0c8331ae6492302a319ed6