### PR TITLE
fix: load ssb-browser-core net module via dynamic import

### DIFF
--- a/packages/worker-ssb/src/instance.ts
+++ b/packages/worker-ssb/src/instance.ts
@@ -1,6 +1,13 @@
 import { useSettings } from '../../../shared/store/settings';
-import { init as initSSB } from 'ssb-browser-core/net';
 import * as ssbBlobs from 'ssb-blobs';
+
+// `ssb-browser-core/net` is a CommonJS module which doesn't expose a default
+// export when bundled for ESM environments (such as Vite). Using a static ES
+// import therefore fails at runtime with "does not provide an export named
+// 'default'". By loading the module dynamically we can access the `init`
+// function from the module namespace regardless of how the bundler expresses
+// its exports.
+const { init: initSSB } = await import('ssb-browser-core/net.js');
 
 let ssb: any = (globalThis as any).__cashuSSB;
 


### PR DESCRIPTION
## Summary
- dynamically import `ssb-browser-core/net` to avoid missing default export error

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688f3b66e08c8331b5359324ea30d429