### PR TITLE
fix: handle browser fs warning and add dialog labels

### DIFF
--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -272,6 +272,10 @@ export default function Onboarding() {
     <Dialog.Root open>
       <Dialog.Overlay className="fixed inset-0 bg-black/50" />
       <Dialog.Content className="fixed inset-0 flex items-center justify-center p-4">
+        <Dialog.Title className="sr-only">Onboarding</Dialog.Title>
+        <Dialog.Description className="sr-only">
+          Set up your profile to start using CashuCast
+        </Dialog.Description>
         <div className="bg-white rounded p-4 w-full max-w-md">
           <OnboardingContent />
         </div>
@@ -288,6 +292,10 @@ export function OnboardingDialog() {
     <Dialog.Root open={open} onOpenChange={setOpen}>
       <Dialog.Overlay className="fixed inset-0 bg-black/50" />
       <Dialog.Content className="fixed inset-0 flex items-center justify-center p-4">
+        <Dialog.Title className="sr-only">Onboarding</Dialog.Title>
+        <Dialog.Description className="sr-only">
+          Set up your profile to start using CashuCast
+        </Dialog.Description>
         <div className="bg-white rounded p-4 w-full max-w-md">
           <OnboardingContent />
         </div>

--- a/ssb-reserved-words-fix.ts
+++ b/ssb-reserved-words-fix.ts
@@ -36,8 +36,13 @@ export default function ssbReservedWordsFix(): VitePlugin {
           .replace("const caps = require('ssb-caps')", "import caps from 'ssb-caps';")
           .replace("const ssbKeys = require('ssb-keys')", "import ssbKeys from 'ssb-keys';")
           .replace("const helpers = require('./core-helpers')", "import helpers from './core-helpers';")
-          .replace("const path = require('path')", "import path from 'path';")
-          .replace('exports.init = function', 'export function init');
+          .replace("const path = require('path')", '')
+          .replace('exports.init = function(dir, overwriteConfig, extraModules) {',
+            'export function init(dir, overwriteConfig = {}, extraModules) {')
+          .replace(
+            "var keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))",
+            'var keys = overwriteConfig.keys || ssbKeys.generate()'
+          );
         return { code: transformed, map: null };
       }
       if (normalized.includes('ssb-browser-core/dist/bundle-core.js')) {
@@ -100,8 +105,13 @@ export function ssbReservedWordsFixEsbuild(): EsbuildPlugin {
           .replace("const caps = require('ssb-caps')", "import caps from 'ssb-caps';")
           .replace("const ssbKeys = require('ssb-keys')", "import ssbKeys from 'ssb-keys';")
           .replace("const helpers = require('./core-helpers')", "import helpers from './core-helpers';")
-          .replace("const path = require('path')", "import path from 'path';")
-          .replace('exports.init = function', 'export function init');
+          .replace("const path = require('path')", '')
+          .replace('exports.init = function(dir, overwriteConfig, extraModules) {',
+            'export function init(dir, overwriteConfig = {}, extraModules) {')
+          .replace(
+            "var keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))",
+            'var keys = overwriteConfig.keys || ssbKeys.generate()'
+          );
         return { contents: code, loader: 'js' };
       });
 


### PR DESCRIPTION
## Summary
- add hidden dialog title + description for onboarding
- avoid fs usage in ssb-browser-core transformation by generating keys in memory

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688f434dda28833191b0701efbac687a