### PR TITLE
chore(web): stub fs in Vite config

### DIFF
--- a/apps/web/empty-module.js
+++ b/apps/web/empty-module.js
@@ -1,0 +1,1 @@
+export default {};

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 import ssbReservedWordsFix, {
   ssbReservedWordsFixEsbuild,
 } from '../../ssb-reserved-words-fix';
-import { resolve } from 'path';
+import path from 'path';
 import tailwindcss from 'tailwindcss';
 import autoprefixer from 'autoprefixer';
 
@@ -16,7 +16,9 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      path: resolve(__dirname, 'path-shim.ts'),
+      path: path.resolve(__dirname, 'path-shim.ts'),
+      // stub fs for browser compatibility
+      fs: path.resolve(__dirname, 'empty-module.js'),
     },
   },
   optimizeDeps: {


### PR DESCRIPTION
## Summary
- add empty-module stub to alias `fs`
- alias `fs` in Vite config so it isn't bundled for the browser

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688f49bc00008331aff7ba07df6b3afa