### PR TITLE
Use IndexedDB storage for SSB worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lucide-react": "^0.536.0",
     "minisearch": "^7.1.2",
     "quick-lru": "^7.0.1",
+    "random-access-idb": "^1.2.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-dropzone": "^14.3.8",

--- a/packages/worker-ssb/src/instance.ts
+++ b/packages/worker-ssb/src/instance.ts
@@ -1,4 +1,5 @@
 import { useSettings } from '../../../shared/store/settings';
+import randomAccessIdb from 'random-access-idb';
 
 // `ssb-browser-core/net` is a CommonJS module which doesn't expose a default
 // export when bundled for ESM environments (such as Vite). Using a static ES
@@ -15,7 +16,10 @@ export function getSSB() {
 
   const { roomUrl } = useSettings.getState();
 
-  ssb = initSSB('cashucast-ssb');
+  ssb = initSSB('cashucast-ssb', {
+    // force IndexedDB storage in Web Workers
+    storage: randomAccessIdb,
+  });
 
   if (roomUrl) {
     try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       quick-lru:
         specifier: ^7.0.1
         version: 7.0.1
+      random-access-idb:
+        specifier: ^1.2.2
+        version: 1.2.2
       react:
         specifier: ^19.1.1
         version: 19.1.1


### PR DESCRIPTION
## Summary
- install random-access-idb and use it in the SSB worker
- configure SSB instance to force IndexedDB storage in Web Workers

## Testing
- `pnpm test`
- `pnpm lint packages/worker-ssb/src/instance.ts`


------
https://chatgpt.com/codex/tasks/task_e_688f4aac4de48331862fa92ff74e35ec