### PR TITLE
chore(web): stub fs module for browser build

### DIFF
--- a/apps/web/src/empty-fs.js
+++ b/apps/web/src/empty-fs.js
@@ -1,0 +1,3 @@
+export const readFile = () => {
+  throw new Error('fs.readFile is not available in the browser');
+};

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     alias: {
       path: path.resolve(__dirname, 'path-shim.ts'),
       // stub fs for browser compatibility
-      fs: path.resolve(__dirname, 'empty-module.js'),
+      fs: path.resolve(__dirname, 'src/empty-fs.js'),
     },
   },
   optimizeDeps: {


### PR DESCRIPTION
## Summary
- add fs.readFile stub for browser environments
- point Vite's fs alias to the new stub module

## Testing
- `pnpm test`
- `pnpm lint apps/web/src/empty-fs.js apps/web/vite.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_688f50c7b0708331b52f62b2aa13ab90