### PR TITLE
Specify Tailwind config path for web app

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -11,7 +11,12 @@ export default defineConfig({
   plugins: [ssbReservedWordsFix(), react()],
   css: {
     postcss: {
-      plugins: [tailwindcss(), autoprefixer()],
+      plugins: [
+        tailwindcss({
+          config: path.resolve(__dirname, '../../tailwind.config.cjs'),
+        }),
+        autoprefixer(),
+      ],
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary
- point Vite's Tailwind plugin to repo-level tailwind.config.cjs

## Testing
- `pnpm lint apps/web/vite.config.ts`
- `pnpm test apps/web`

------
https://chatgpt.com/codex/tasks/task_e_688fb91a1dfc83319204680caa60f14b