### PR TITLE
fix: replace invalid Tailwind class in TimelineCard

### DIFF
--- a/apps/web/src/components/TimelineCard.tsx
+++ b/apps/web/src/components/TimelineCard.tsx
@@ -103,7 +103,7 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({
           </BlurOverlay>
         )}
         <div className="absolute bottom-0 left-0 right-0 text-white">
-          <div className={`flex items-center justify-between p-4 ${text ? 'mb-[-8px]' : ''}`}>
+          <div className={`flex items-center justify-between p-4 ${text ? '-mb-2' : ''}`}>
             <button
               type="button"
               className="flex items-center gap-2"


### PR DESCRIPTION
## Summary
- fix negative margin class in TimelineCard so Tailwind compiles

## Testing
- `pnpm lint apps/web/src/components/TimelineCard.tsx`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688fba2efcd88331af0cbd6f24f288ab