### PR TITLE
docs: document SSB reserved word fix plugins

### DIFF
--- a/ssb-reserved-words-fix.ts
+++ b/ssb-reserved-words-fix.ts
@@ -2,10 +2,25 @@
  * Licensed under GPL-3.0-or-later
  * ssb-reserved-words-fix module.
  */
+/**
+ * Provides Vite and Esbuild plugins that rewrite Secure Scuttlebutt (SSB) modules
+ * which use JavaScript reserved words or Node.js-only patterns. The plugins run
+ * during bundling to rename problematic identifiers and adjust imports so the
+ * modules can be processed by modern tooling for browser builds.
+ */
 import type { Plugin as VitePlugin } from 'vite';
 import type { Plugin as EsbuildPlugin } from 'esbuild';
 import { readFile } from 'fs/promises';
 
+/**
+ * Create a Vite plugin that patches SSB dependencies before other transforms.
+ * It targets files that contain identifiers such as `private` or `public` and
+ * replaces them with safe alternatives while also converting CommonJS `require`
+ * calls to ESM imports where necessary. Include this plugin in the Vite config
+ * when bundling the SSB stack for the browser.
+ *
+ * @returns {VitePlugin} Vite plugin that rewrites reserved words and imports.
+ */
 export default function ssbReservedWordsFix(): VitePlugin {
   return {
     name: 'ssb-reserved-words-fix',
@@ -73,6 +88,14 @@ export default function ssbReservedWordsFix(): VitePlugin {
   };
 }
 
+/**
+ * Create an esbuild plugin that performs the same transformations as
+ * {@link ssbReservedWordsFix} using esbuild's `onLoad` hooks. It rewrites the
+ * contents of SSB-related files on the fly to avoid reserved words and to adjust
+ * imports, making the modules compatible with esbuild-based tooling.
+ *
+ * @returns {EsbuildPlugin} Esbuild plugin applying the SSB fixes.
+ */
 export function ssbReservedWordsFixEsbuild(): EsbuildPlugin {
   return {
     name: 'ssb-reserved-words-fix-esbuild',


### PR DESCRIPTION
## Summary
- describe purpose of SSB reserved word fix plugins
- add JSDoc for Vite and esbuild plugin variants

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688fbea8273c8331984f2015a9424578