### PR TITLE
Remove Record tab from bottom nav

### DIFF
--- a/shared/ui/BottomNav.test.tsx
+++ b/shared/ui/BottomNav.test.tsx
@@ -12,6 +12,7 @@ describe('BottomNav', () => {
     const html = renderToStaticMarkup(<BottomNav />);
     expect(html).toContain('Home');
     expect(html).toContain('href="/discover"');
+    expect(html).not.toContain('href="/record"');
     expect(html).toContain('+');
     expect(html).toContain('Profile');
   });

--- a/shared/ui/BottomNav.tsx
+++ b/shared/ui/BottomNav.tsx
@@ -58,15 +58,6 @@ export const BottomNav: React.FC = () => {
           <span className="sr-only">Discover</span>
         </motion.a>
         <motion.a
-          href="/record"
-          aria-label="Record"
-          className="text-2xl text-gray-900 dark:text-gray-100 focus:outline-none focus:ring"
-          animate={{ scale: path === '/record' ? 1.2 : 1 }}
-          transition={{ type: 'spring', stiffness: 400, damping: 20 }}
-        >
-          +
-        </motion.a>
-        <motion.a
           href="/profile"
           aria-label="Profile"
           className="text-gray-900 dark:text-gray-100 focus:outline-none focus:ring"


### PR DESCRIPTION
## Summary
- remove Record tab link from bottom nav
- keep FabRecord button as sole record entry
- adjust BottomNav tests for new nav behavior

## Testing
- `pnpm test shared/ui/BottomNav.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688fc544081c8331a7a0182983880a3e