### PR TITLE
refactor: use dialog for stepper

### DIFF
--- a/shared/ui/InstallBanner.tsx
+++ b/shared/ui/InstallBanner.tsx
@@ -42,6 +42,7 @@ export const InstallBanner: React.FC<InstallBannerProps> = ({ onFinish }) => {
       <button
         onClick={install}
         className="rounded bg-blue-500 px-4 py-2 text-white"
+        autoFocus
       >
         {deferred ? 'Install' : 'Continue'}
       </button>

--- a/shared/ui/MintSelect.tsx
+++ b/shared/ui/MintSelect.tsx
@@ -26,7 +26,11 @@ export const MintSelect: React.FC<MintSelectProps> = ({ onNext }) => {
   return (
     <div>
       <h2 className="mb-2 text-lg font-semibold">Select Default Mint</h2>
-      <MintPicker value={mint} onChange={(e) => setMint(e.target.value)} />
+      <MintPicker
+        value={mint}
+        onChange={(e) => setMint(e.target.value)}
+        autoFocus
+      />
       <button
         onClick={handleNext}
         className="mt-4 rounded bg-blue-500 px-4 py-2 text-white"

--- a/shared/ui/Stepper.tsx
+++ b/shared/ui/Stepper.tsx
@@ -3,6 +3,7 @@
  * React component for Stepper.
  */
 import React from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
 import { MintSelect } from './MintSelect';
 import { InstallBanner } from './InstallBanner';
 
@@ -37,50 +38,57 @@ export const Stepper: React.FC = () => {
   if (!open || step >= TOTAL_STEPS) return null;
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black/50">
-      <div className="w-full max-w-sm rounded bg-white p-4 sm:p-6 mx-4 sm:mx-0">
-        <div
-          role="progressbar"
-          aria-valuenow={step + 1}
-          aria-valuemin={1}
-          aria-valuemax={TOTAL_STEPS}
-          className="mb-4 text-sm text-gray-500"
+    <Dialog.Root open={open}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50" />
+        <Dialog.Content
+          aria-modal="true"
+          className="fixed left-1/2 top-1/2 w-full max-w-sm -translate-x-1/2 -translate-y-1/2 rounded bg-white p-4 sm:p-6 mx-4 sm:mx-0 focus:outline-none"
         >
-          Step {step + 1} of {TOTAL_STEPS}
-        </div>
-        {step === 0 && (
-          <div>
-            <h2 className="mb-2 text-lg font-semibold">Choose a username</h2>
-            <label htmlFor="stepper-username" className="sr-only">
-              Username
-            </label>
-            <input
-              id="stepper-username"
-              name="username"
-              className="mb-4 w-full rounded border p-2"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              placeholder="Username"
-              autoComplete="username"
-            />
-            <button
-              disabled={!username}
-              aria-disabled={!username}
-              onClick={() => {
-                if (typeof window !== 'undefined') {
-                  localStorage.setItem('username', username);
-                }
-                setStep(1);
-              }}
-              className="rounded bg-blue-600 px-4 py-2 text-white disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              Next
-            </button>
+          <div
+            role="progressbar"
+            aria-valuenow={step + 1}
+            aria-valuemin={1}
+            aria-valuemax={TOTAL_STEPS}
+            className="mb-4 text-sm text-gray-500"
+          >
+            Step {step + 1} of {TOTAL_STEPS}
           </div>
-        )}
-        {step === 1 && <MintSelect onNext={() => setStep(2)} />}
-        {step === 2 && <InstallBanner onFinish={complete} />}
-      </div>
-    </div>
+          {step === 0 && (
+            <div>
+              <h2 className="mb-2 text-lg font-semibold">Choose a username</h2>
+              <label htmlFor="stepper-username" className="sr-only">
+                Username
+              </label>
+              <input
+                id="stepper-username"
+                name="username"
+                className="mb-4 w-full rounded border p-2"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                placeholder="Username"
+                autoComplete="username"
+                autoFocus
+              />
+              <button
+                disabled={!username}
+                aria-disabled={!username}
+                onClick={() => {
+                  if (typeof window !== 'undefined') {
+                    localStorage.setItem('username', username);
+                  }
+                  setStep(1);
+                }}
+                className="rounded bg-blue-600 px-4 py-2 text-white disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Next
+              </button>
+            </div>
+          )}
+          {step === 1 && <MintSelect onNext={() => setStep(2)} />}
+          {step === 2 && <InstallBanner onFinish={complete} />}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 };


### PR DESCRIPTION
## Summary
- replace Stepper overlay div with Radix Dialog for better a11y
- focus first control for each onboarding step

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688fc5ebfe388331bba0f9156525df79