### PR TITLE
feat: add upload long press

### DIFF
--- a/apps/web/playwright/fabRecord.pw.tsx
+++ b/apps/web/playwright/fabRecord.pw.tsx
@@ -1,0 +1,30 @@
+/*
+ * Licensed under GPL-3.0-or-later
+ * Test suite for FabRecord long press behavior.
+ */
+import React from 'react';
+import { test, expect } from '@playwright/experimental-ct-react';
+import FabRecord from '../../shared/ui/FabRecord';
+
+// Short tap should navigate to /record
+
+test('short tap navigates to /record', async ({ mount, page }) => {
+  await mount(<FabRecord />);
+  await page.getByRole('button', { name: 'Record' }).click();
+  await expect(page).toHaveURL('/record');
+});
+
+// Long press should open file selector and navigate to /compose
+
+test('long press opens file selector and navigates to /compose', async ({ mount, page }) => {
+  await mount(<FabRecord />);
+  const button = page.getByRole('button', { name: 'Record' });
+  await button.dispatchEvent('mousedown');
+  await page.waitForTimeout(600);
+  const file = new File(['vid'], 'vid.mp4', { type: 'video/mp4' });
+  await page.setInputFiles('input[type="file"]', file);
+  await button.dispatchEvent('mouseup');
+  await expect(page).toHaveURL('/compose');
+  const name = await page.evaluate(() => window.recordedFile?.name);
+  expect(name).toBe('vid.mp4');
+});

--- a/apps/web/src/routes/Compose.tsx
+++ b/apps/web/src/routes/Compose.tsx
@@ -2,7 +2,7 @@
  * Licensed under GPL-3.0-or-later
  * React component for Compose.
  */
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   UploadDropzone,
   TranscodeModal,
@@ -26,6 +26,13 @@ export default function Compose() {
     setMagnet(null);
     setThumbHash(null);
   };
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.recordedFile) {
+      handleFile(window.recordedFile);
+      window.recordedFile = undefined;
+    }
+  }, []);
 
   const onPublish = async () => {
     if (!magnet) return;

--- a/packages/ambient.d.ts
+++ b/packages/ambient.d.ts
@@ -9,3 +9,7 @@ declare module 'ssb-blobs';
 declare module 'webtorrent';
 declare module 'bittorrent-dht';
 declare module 'wrtc';
+
+interface Window {
+  recordedFile?: File;
+}

--- a/shared/ui/FabRecord.tsx
+++ b/shared/ui/FabRecord.tsx
@@ -2,24 +2,63 @@
  * Licensed under GPL-3.0-or-later
  * React component for FabRecord.
  */
-import React from 'react';
+import React, { useRef } from 'react';
 
 const FabRecord: React.FC = () => {
-  const handleClick = () => {
-    if (typeof window !== 'undefined') {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressRef = useRef(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const startPress = () => {
+    longPressRef.current = false;
+    timerRef.current = setTimeout(() => {
+      longPressRef.current = true;
+      inputRef.current?.click();
+    }, 500);
+  };
+
+  const endPress = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    if (!longPressRef.current && typeof window !== 'undefined') {
       window.history.pushState(null, '', '/record');
       window.dispatchEvent(new PopStateEvent('popstate'));
     }
   };
 
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file && typeof window !== 'undefined') {
+      window.recordedFile = file;
+      window.history.pushState(null, '', '/compose');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+      e.target.value = '';
+    }
+  };
+
   return (
-    <button
-      onClick={handleClick}
-      aria-label="Record"
-      className="fixed bottom-16 left-1/2 -translate-x-1/2 z-50 flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-r from-[#FF0759] to-[#FF8A90] text-white drop-shadow-lg motion-safe:hover:scale-105 sm:hidden"
-    >
-      +
-    </button>
+    <>
+      <button
+        onMouseDown={startPress}
+        onTouchStart={startPress}
+        onMouseUp={endPress}
+        onTouchEnd={endPress}
+        onMouseLeave={endPress}
+        aria-label="Record"
+        className="fixed bottom-16 left-1/2 -translate-x-1/2 z-50 flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-r from-[#FF0759] to-[#FF8A90] text-white drop-shadow-lg motion-safe:hover:scale-105 sm:hidden"
+      >
+        +
+      </button>
+      <input
+        type="file"
+        accept="video/*"
+        ref={inputRef}
+        className="hidden"
+        onChange={handleChange}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- add long-press behavior to record FAB to trigger video upload
- load `window.recordedFile` on compose
- test short tap vs long press

## Testing
- `pnpm lint`
- `pnpm test`
- `npx playwright test` *(fails: Test timeout of 30000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_688fc6a0a1948331b7b1d41533ef4857