### PR TITLE
Use webm input for thumbnail extraction

### DIFF
--- a/apps/web/src/components/ThumbnailPicker.test.tsx
+++ b/apps/web/src/components/ThumbnailPicker.test.tsx
@@ -1,0 +1,73 @@
+/*
+ * Licensed under GPL-3.0-or-later
+ * Test suite for ThumbnailPicker.
+ */
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+
+const load = vi.fn(async () => {});
+const writeFile = vi.fn(async () => {});
+const exec = vi.fn(async () => {});
+const readFile = vi.fn(async () => new Uint8Array([1]));
+
+vi.mock('@ffmpeg/ffmpeg', () => ({
+  FFmpeg: class {
+    load = load;
+    writeFile = writeFile;
+    exec = exec;
+    readFile = readFile;
+  },
+}));
+
+import ThumbnailPicker from './ThumbnailPicker';
+
+describe('ThumbnailPicker', () => {
+  it('extracts thumbnails from input.webm at given timestamps', async () => {
+    (global as any).URL.createObjectURL = vi.fn(() => 'blob:mock');
+    const file = {
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    } as unknown as Blob;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(<ThumbnailPicker file={file} onSelect={() => {}} />);
+    });
+    await act(async () => {});
+    expect(writeFile).toHaveBeenCalledWith('input.webm', expect.any(Uint8Array));
+    expect(exec).toHaveBeenCalledTimes(3);
+    expect(exec.mock.calls[0][0]).toEqual([
+      '-ss',
+      '00:00:01',
+      '-i',
+      'input.webm',
+      '-frames:v',
+      '1',
+      'out0.jpg',
+    ]);
+    expect(exec.mock.calls[1][0]).toEqual([
+      '-ss',
+      '00:00:02',
+      '-i',
+      'input.webm',
+      '-frames:v',
+      '1',
+      'out1.jpg',
+    ]);
+    expect(exec.mock.calls[2][0]).toEqual([
+      '-ss',
+      '00:00:03',
+      '-i',
+      'input.webm',
+      '-frames:v',
+      '1',
+      'out2.jpg',
+    ]);
+  });
+});
+

--- a/apps/web/src/components/ThumbnailPicker.tsx
+++ b/apps/web/src/components/ThumbnailPicker.tsx
@@ -25,11 +25,11 @@ export default function ThumbnailPicker({ file, onSelect }: ThumbnailPickerProps
     const run = async () => {
       const ffmpeg = new FFmpeg();
       await ffmpeg.load();
-      await ffmpeg.writeFile('input.mp4', new Uint8Array(await file.arrayBuffer()));
+      await ffmpeg.writeFile('input.webm', new Uint8Array(await file.arrayBuffer()));
       const times = ['00:00:01', '00:00:02', '00:00:03'];
       const imgs: { src: string; blob: Blob }[] = [];
       for (let i = 0; i < times.length; i++) {
-        await ffmpeg.exec(['-ss', times[i], '-i', 'input.mp4', '-frames:v', '1', `out${i}.jpg`]);
+        await ffmpeg.exec(['-ss', times[i], '-i', 'input.webm', '-frames:v', '1', `out${i}.jpg`]);
         const data = await ffmpeg.readFile(`out${i}.jpg`);
         const blob = new Blob([data], { type: 'image/jpeg' });
         imgs.push({ src: URL.createObjectURL(blob), blob });


### PR DESCRIPTION
## Summary
- write uploaded video as `input.webm`
- test ffmpeg thumbnail extraction from webm input

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688fc803a4408331be28a4848d572f26