### PR TITLE
Use WebM MIME type for torrent worker and tests

### DIFF
--- a/apps/web/playwright/posting.pw.tsx
+++ b/apps/web/playwright/posting.pw.tsx
@@ -29,7 +29,7 @@ test('posting flow publishes a post', async ({ mount, page }) => {
   });
 
   const component = await mount(<TestCompose />);
-  const file = new File(['vid'], 'vid.mp4', { type: 'video/mp4' });
+  const file = new File(['vid'], 'vid.webm', { type: 'video/webm' });
   await page.setInputFiles('input[type="file"]', file);
   await component.getByText('Publish').click();
   await expect(await page.evaluate(() => (window as any).__publishCalled)).toBe(true);

--- a/packages/integration/__tests__/flow.test.ts
+++ b/packages/integration/__tests__/flow.test.ts
@@ -11,7 +11,7 @@ const { seedMock, addMock } = vi.hoisted(() => ({
     cb({ magnetURI: 'magnet:?xt=urn:btih:test', files: [{ getBlob: (cb2: any) => cb2(null, file) }] })
   ),
   addMock: vi.fn((_magnet: string, _opts: any, cb: any) => {
-    const blob = new Blob(['data'], { type: 'video/mp4' });
+    const blob = new Blob(['data'], { type: 'video/webm' });
     cb({ files: [{ getBlob: (cb2: any) => cb2(null, blob) }] });
   }),
 }));
@@ -123,7 +123,7 @@ describe('integration flow', () => {
     await cashu.call('initWallet', undefined);
     await cashu.call('mint', 5);
 
-    const magnet = (await torrent.call('seedFile', new Blob(['video']))) as string;
+    const magnet = (await torrent.call('seedFile', new Blob(['video'], { type: 'video/webm' }))) as string;
     await ssb.call('publishPost', {
       id: 'v1',
       magnet,

--- a/packages/worker-torrent/__tests__/torrent.test.ts
+++ b/packages/worker-torrent/__tests__/torrent.test.ts
@@ -11,7 +11,7 @@ const { seedMock, addMock } = vi.hoisted(() => ({
     cb({ magnetURI: 'magnet:?xt=urn:btih:test', files: [{ getBlob: (cb2: any) => cb2(null, file) }] })
   ),
   addMock: vi.fn((_magnet: string, _opts: any, cb: any) => {
-    const blob = new Blob(['data'], { type: 'video/mp4' });
+    const blob = new Blob(['data'], { type: 'video/webm' });
     cb({ files: [{ getBlob: (cb2: any) => cb2(null, blob) }] });
   }),
 }));
@@ -116,7 +116,7 @@ async function setup(ssbHasBlob: boolean) {
 describe('worker-torrent', () => {
   it('seeds a file and returns a magnet URI', async () => {
     const { call, clientMock, cleanup } = await setup(false);
-    const magnet = await call('seedFile', new Blob(['hello']));
+    const magnet = await call('seedFile', new Blob(['hello'], { type: 'video/webm' }));
     expect(clientMock.seed).toHaveBeenCalled();
     expect(magnet).toMatch(/^magnet:/);
     cleanup();

--- a/packages/worker-torrent/src/index.ts
+++ b/packages/worker-torrent/src/index.ts
@@ -86,7 +86,7 @@ async function stream(magnet: string): Promise<string> {
         const chunks: BlobPart[] = [];
         blobStream.on('data', (ch: Uint8Array) => chunks.push(new Uint8Array(ch)));
         blobStream.on('end', () => {
-          const file = new Blob(chunks, { type: 'video/mp4' });
+          const file = new Blob(chunks, { type: 'video/webm' });
           touch(infoHash, file.size);
           resolve(URL.createObjectURL(file));
         });


### PR DESCRIPTION
## Summary
- Stream cached torrents as WebM blobs
- Update torrent worker and integration tests to use `video/webm`
- Upload a `.webm` file in Playwright posting test

## Testing
- `pnpm test`
- `pnpm exec playwright test apps/web/playwright/posting.pw.tsx` *(fails: Test timeout of 30000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_688fc9ab711083318ce38d8e871f2a56