### PR TITLE
feat: validate video uploads

### DIFF
--- a/shared/ui/UploadDropzone.test.tsx
+++ b/shared/ui/UploadDropzone.test.tsx
@@ -1,0 +1,37 @@
+/*
+ * Licensed under GPL-3.0-or-later
+ * Test suite for UploadDropzone.
+ */
+/** @vitest-environment jsdom */
+
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { createRoot } from 'react-dom/client';
+import { describe, it, expect, vi } from 'vitest';
+import { UploadDropzone } from './UploadDropzone';
+
+describe('UploadDropzone', () => {
+  it('limits selection to video files', () => {
+    const html = renderToStaticMarkup(<UploadDropzone onFile={() => {}} />);
+    expect(html).toContain('accept="video/*"');
+  });
+
+  it('shows error for non-video files', async () => {
+    const onFile = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    root.render(<UploadDropzone onFile={onFile} />);
+    await new Promise((r) => setTimeout(r, 0));
+    const input = container.querySelector('input') as HTMLInputElement;
+    const file = new File(['test'], 'test.txt', { type: 'text/plain' });
+    Object.defineProperty(input, 'files', { value: [file] });
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onFile).not.toHaveBeenCalled();
+    const error = container.querySelector('.text-red-600');
+    expect(error?.textContent).toBe('Please select a video file.');
+    root.unmount();
+    container.remove();
+  });
+});

--- a/shared/ui/UploadDropzone.tsx
+++ b/shared/ui/UploadDropzone.tsx
@@ -13,15 +13,27 @@ export interface UploadDropzoneProps {
 }
 
 export const UploadDropzone: React.FC<UploadDropzoneProps> = ({ onFile }) => {
+  const [error, setError] = React.useState('');
+
+  const validate = (file?: File) => {
+    if (!file) return;
+    if (file.type.startsWith('video/')) {
+      setError('');
+      onFile(file);
+    } else {
+      setError('Please select a video file.');
+    }
+  };
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (file) onFile(file);
+    validate(file);
   };
 
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     const file = e.dataTransfer.files?.[0];
-    if (file) onFile(file);
+    validate(file);
   };
 
   return (
@@ -37,9 +49,13 @@ export const UploadDropzone: React.FC<UploadDropzoneProps> = ({ onFile }) => {
         id="file-upload"
         name="file"
         type="file"
+        accept="video/*"
         onChange={handleChange}
       />
       <p className="text-center text-sm mt-2">Drop or select a video file</p>
+      {error && (
+        <p className="text-center text-sm mt-2 text-red-600">{error}</p>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- restrict UploadDropzone input to video files and show an error when other files are chosen
- add tests covering video-only uploads

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688fcb8fa06c8331ae4b267782a638bd