### PR TITLE
Ensure webm support for torrent playback

### DIFF
--- a/apps/web/playwright/fabRecord.pw.tsx
+++ b/apps/web/playwright/fabRecord.pw.tsx
@@ -21,10 +21,10 @@ test('long press opens file selector and navigates to /compose', async ({ mount,
   const button = page.getByRole('button', { name: 'Record' });
   await button.dispatchEvent('mousedown');
   await page.waitForTimeout(600);
-  const file = new File(['vid'], 'vid.mp4', { type: 'video/mp4' });
+  const file = new File(['vid'], 'vid.webm', { type: 'video/webm' });
   await page.setInputFiles('input[type="file"]', file);
   await button.dispatchEvent('mouseup');
   await expect(page).toHaveURL('/compose');
   const name = await page.evaluate(() => window.recordedFile?.name);
-  expect(name).toBe('vid.mp4');
+  expect(name).toBe('vid.webm');
 });

--- a/packages/worker-torrent/__tests__/torrent.test.ts
+++ b/packages/worker-torrent/__tests__/torrent.test.ts
@@ -124,18 +124,26 @@ describe('worker-torrent', () => {
 
   it('streams from ssb blob cache when available', async () => {
     const { call, clientMock, cleanup } = await setup(true);
+    const spy = vi.spyOn(URL, 'createObjectURL');
     const url = (await call('stream', 'magnet:?xt=urn:btih:test')) as string;
     expect(clientMock.add).not.toHaveBeenCalled();
     expect(url.startsWith('blob:')).toBe(true);
+    expect(spy).toHaveBeenCalled();
+    expect((spy.mock.calls[0][0] as Blob).type).toBe('video/webm');
+    spy.mockRestore();
     cleanup();
   });
 
   it('falls back to torrent when blob cache misses', async () => {
     const { call, clientMock, ssb, cleanup } = await setup(false);
+    const spy = vi.spyOn(URL, 'createObjectURL');
     const url = (await call('stream', 'magnet:?xt=urn:btih:test')) as string;
     expect(clientMock.add).toHaveBeenCalled();
     expect(ssb.blobs.add).toHaveBeenCalled();
     expect(url.startsWith('blob:')).toBe(true);
+    expect(spy).toHaveBeenCalled();
+    expect((spy.mock.calls[0][0] as Blob).type).toBe('video/webm');
+    spy.mockRestore();
     cleanup();
   });
 });

--- a/shared/ui/VideoPlayer.test.tsx
+++ b/shared/ui/VideoPlayer.test.tsx
@@ -2,10 +2,23 @@
  * Licensed under GPL-3.0-or-later
  * Test suite for VideoPlayer.
  */
-import React from 'react';
+import React, { act } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { describe, it, expect } from 'vitest';
+import ReactDOM from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+import { describe, it, expect, vi } from 'vitest';
 import { VideoPlayer } from './VideoPlayer';
+
+const blobUrl = URL.createObjectURL(new Blob(['data'], { type: 'video/ogg' }));
+
+vi.mock('../rpc', () => ({
+  createRPCClient: () => () => Promise.resolve(blobUrl),
+}));
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+(globalThis as any).window = dom.window as any;
+(globalThis as any).document = dom.window.document;
+(globalThis as any).navigator = dom.window.navigator;
 
 describe('VideoPlayer', () => {
   it('renders a skeleton loader while awaiting the stream URL', () => {
@@ -13,5 +26,22 @@ describe('VideoPlayer', () => {
       <VideoPlayer magnet="magnet:?xt=urn:btih:test" />
     );
     expect(html).toContain('bg-gray-200');
+  });
+
+  it('renders a video element once the blob URL resolves', async () => {
+    (globalThis as any).Worker = class {
+      terminate() {}
+    };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+    await act(async () => {
+      root.render(<VideoPlayer magnet="magnet:?xt=urn:btih:test" />);
+      await Promise.resolve();
+    });
+    const video = container.querySelector('video') as HTMLVideoElement;
+    expect(video).toBeTruthy();
+    expect(video.src).toBe(blobUrl);
+    root.unmount();
   });
 });


### PR DESCRIPTION
## Summary
- add integration test confirming VideoPlayer accepts any blob type
- test torrent worker emits webm blobs and update Playwright fixture to webm

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fcd0127e08331ad4324e8dc4ce9d5