### PR TITLE
feat(web): finalize onboarding step

### DIFF
--- a/apps/web/src/routes/Onboarding.test.tsx
+++ b/apps/web/src/routes/Onboarding.test.tsx
@@ -168,4 +168,35 @@ describe('Onboarding steps', () => {
     });
     expect(container.textContent).toContain('Step 2 of 3');
   });
+
+  it('allows user to reach final confirmation step via import flow', async () => {
+    const { container, root } = setupDom();
+    await act(async () => {
+      root.render(<Onboarding />);
+    });
+    const importBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Import Existing Profile'),
+    )!;
+    await act(async () => {
+      importBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      useProfile.setState({
+        profile: {
+          ssbPk: 'pk',
+          ssbSk: 'sk',
+          cashuMnemonic: 'mnemonic',
+          username: 'alice',
+        } as any,
+      });
+    });
+    const nextBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Next',
+    )!;
+    await act(async () => {
+      nextBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.textContent).toContain('Step 3 of 3');
+    expect(container.textContent).toContain('Confirm');
+  });
 });

--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -116,9 +116,16 @@ function OnboardingContent() {
         touch(hash, data.byteLength);
         setAvatarHash(hash);
         setAvatarPreview(URL.createObjectURL(blob));
+        const err = validateUsername(username);
+        if (err) {
+          setUsernameError(err);
+          setStep(2);
+        } else {
+          setStep(3);
+        }
       });
     }, 'image/jpeg');
-  }, [avatarSrc, croppedArea]);
+  }, [avatarSrc, croppedArea, username]);
 
   // import states
   const [profileJson, setProfileJson] = useState<any>(null);
@@ -483,7 +490,7 @@ function OnboardingContent() {
               className="rounded bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 sm:px-6 sm:py-3 md:px-8 md:py-4"
               onClick={confirm}
             >
-              Next
+              Confirm
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- advance to confirmation after avatar save with username validation
- label final onboarding action as "Confirm"
- test reaching final step in import flow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fd79efbe083318e0784b07e707bd0