### PR TITLE
feat(web): preview avatar after crop

### DIFF
--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -312,27 +312,29 @@ function OnboardingContent() {
                   onCropComplete={onCropComplete}
                 />
               </div>
-              <button
-                className="rounded bg-blue-700 hover:bg-blue-800 text-white px-4 py-3 min-w-[44px] min-h-[44px]"
-                onClick={async () => {
-                  const preview = await saveAvatar();
-                  if (!preview) return;
-                  setAvatarPreview(preview);
-                  const err = validateUsername(username);
-                  if (err) {
-                    setUsernameError(err);
-                    setStep(2);
-                  } else {
-                    setStep(3);
-                  }
-                }}
-              >
-                Use Avatar
-              </button>
+              {!avatarPreview && (
+                <button
+                  className="rounded bg-blue-700 hover:bg-blue-800 text-white px-4 py-3 min-w-[44px] min-h-[44px]"
+                  onClick={async () => {
+                    const preview = await saveAvatar();
+                    if (!preview) return;
+                    setAvatarPreview(preview);
+                    const err = validateUsername(username);
+                    if (err) {
+                      setUsernameError(err);
+                      setStep(2);
+                    } else {
+                      setStep(3);
+                    }
+                  }}
+                >
+                  Use Avatar
+                </button>
+              )}
               {avatarPreview && (
                 <img
                   src={avatarPreview}
-                  className="w-16 h-16 rounded-full mt-2"
+                  className="w-32 h-32 rounded-full border object-cover mt-2"
                 />
               )}
             </div>


### PR DESCRIPTION
## Summary
- show 128x128 avatar preview after cropping
- hide "Use Avatar" button once an avatar is selected

## Testing
- `pnpm lint apps/web/src/routes/Onboarding.tsx`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688fdf1a5d2c833195cfc59718701fce