### PR TITLE
Add labels for backup dropzones in onboarding

### DIFF
--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -368,6 +368,7 @@ function OnboardingContent() {
       {step === 2 && mode === 'import' && (
         <div className="space-y-4">
           <h2 className="text-xl font-semibold">Import Backups</h2>
+          <h3 className="text-lg font-medium">Profile Backup</h3>
           <Dropzone
             onDrop={async (files) => {
               const f = files[0];
@@ -418,6 +419,7 @@ function OnboardingContent() {
               </div>
             )}
           </Dropzone>
+          <h3 className="text-lg font-medium">Wallet Backup</h3>
           <Dropzone
             onDrop={async (files) => {
               const f = files[0];


### PR DESCRIPTION
## Summary
- add a "Profile Backup" label above the profile backup dropzone in the import flow
- add a "Wallet Backup" label above the wallet backup dropzone

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688fe2a1b0b083319c6cfd9ca5ab22c7