### PR TITLE
feat: validate profile and wallet backups separately

### DIFF
--- a/apps/web/src/routes/Onboarding.test.tsx
+++ b/apps/web/src/routes/Onboarding.test.tsx
@@ -138,7 +138,7 @@ describe('Onboarding steps', () => {
       Object.defineProperty(input, 'files', { value: [file] });
       input.dispatchEvent(new Event('change', { bubbles: true }));
     });
-    expect(container.textContent).toContain('Invalid JSON');
+    expect(container.textContent).toContain('Invalid profile backup');
   });
 
   it('shows step indicator and Back navigation', async () => {


### PR DESCRIPTION
## Summary
- validate profile and wallet backups independently during onboarding
- parse each backup with its own schema and show success or error feedback
- adjust onboarding tests for new error messaging

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fe4370b8883319c9d30986ab508fe