### PR TITLE
Allow RPC init methods to accept zero arguments

### DIFF
--- a/shared/rpc/index.test.ts
+++ b/shared/rpc/index.test.ts
@@ -22,4 +22,15 @@ describe('RPC helpers', () => {
     const call = createRPCClient(port1 as any);
     expect(() => call('mint', 'bad' as any)).toThrow();
   });
+
+  it('allows init methods with no arguments', async () => {
+    const { port1, port2 } = new MessageChannel();
+    const call = createRPCClient(port1 as any);
+    createRPCHandler(port2 as any, {
+      initKeys: async () => ({ pk: 'pk', sk: 'sk' }),
+      initWallet: async () => 'mnemonic',
+    });
+    await expect(call('initKeys')).resolves.toEqual({ pk: 'pk', sk: 'sk' });
+    await expect(call('initWallet')).resolves.toBe('mnemonic');
+  });
 });

--- a/shared/rpc/index.ts
+++ b/shared/rpc/index.ts
@@ -19,6 +19,19 @@ const TopTagsOpts = z.object({
 const FileSchema = z.any();
 const Magnet = z.any();
 
+const InitKeysSchema = z
+  .tuple([])
+  .rest(z.string().optional())
+  .refine((args) => args.length <= 2, {
+    message: 'Expected at most 2 arguments',
+  });
+const InitWalletSchema = z
+  .tuple([])
+  .rest(z.string().optional())
+  .refine((args) => args.length <= 1, {
+    message: 'Expected at most 1 argument',
+  });
+
 export const MethodDefinitions = {
   publishPost: z.tuple([PostSchema]),
   queryFeed: z.tuple([QueryOpts]),
@@ -31,8 +44,8 @@ export const MethodDefinitions = {
   stream: z.tuple([Magnet]),
   mint: z.tuple([z.number()]),
   sendZap: z.tuple([z.string(), z.number(), z.string()]),
-  initKeys: z.tuple([z.string().optional(), z.string().optional()]),
-  initWallet: z.tuple([z.string().optional()]),
+  initKeys: InitKeysSchema,
+  initWallet: InitWalletSchema,
   // allow 0, 1, or 2 files (we’ll guard in UI)
   importProfile: z.tuple([z.array(ProfileSchema).min(0).max(2)]),
 } as const;
@@ -71,7 +84,7 @@ type RPCPort = {
   start?: () => void;
 };
 
-const methodArgSchemas: Record<MethodName, z.ZodTuple<any, any>> = {
+const methodArgSchemas: Record<MethodName, z.ZodTypeAny> = {
   publishPost: MethodDefinitions.publishPost,
   queryFeed: MethodDefinitions.queryFeed,
   reportPost: MethodDefinitions.reportPost,


### PR DESCRIPTION
## Summary
- allow calling `initKeys` and `initWallet` with no parameters
- broaden methodArgSchemas to accept new schemas
- test no-arg init calls

## Testing
- `pnpm test`
- `npx playwright test apps/web/playwright/onboarding.pw.tsx` *(fails: browserType.launch: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688fe44bb3e0833185200363ff17841e