### PR TITLE
Use dynamic SSB init and test avatar upload path

### DIFF
--- a/packages/worker-ssb/__tests__/instance.test.ts
+++ b/packages/worker-ssb/__tests__/instance.test.ts
@@ -1,0 +1,18 @@
+/*
+ * Licensed under GPL-3.0-or-later
+ *
+ * Ensures that `getSSB` returns a usable instance for operations such as
+ * avatar uploads which rely on the blobs API.
+ */
+import { describe, expect, it } from 'vitest';
+import { getSSB } from '../src/instance';
+
+describe('getSSB', () => {
+  it('exposes a blobs.add function for avatar uploads', () => {
+    const ssb = getSSB();
+    expect(ssb).toBeTruthy();
+    expect(ssb.blobs).toBeDefined();
+    expect(typeof ssb.blobs.add).toBe('function');
+  });
+});
+

--- a/packages/worker-ssb/src/instance.ts
+++ b/packages/worker-ssb/src/instance.ts
@@ -14,7 +14,8 @@ import randomAccessIdb from 'random-access-idb';
 // 'default'". By loading the module dynamically we can access the `init`
 // function from the module namespace regardless of how the bundler expresses
 // its exports.
-const { init: initSSB } = await import('ssb-browser-core/net.js');
+const mod = await import('ssb-browser-core/net.js');
+const initSSB = mod.init ?? mod.default;
 
 let ssb: any = (globalThis as any).__cashuSSB;
 


### PR DESCRIPTION
## Summary
- load `ssb-browser-core/net.js` dynamically and derive the `init` function from either `init` or `default`
- add regression test ensuring `getSSB()` exposes `blobs.add` needed for avatar uploads

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fe98a48a083318fb14f5b14a7a19b