### PR TITLE
fix: polyfill window in SSB worker

### DIFF
--- a/packages/worker-ssb/index.ts
+++ b/packages/worker-ssb/index.ts
@@ -22,6 +22,11 @@ if (!globalThis.Buffer) {
   (globalThis as any).Buffer = Buffer;
 }
 
+if (typeof window === 'undefined') {
+  (globalThis as any).window = globalThis;
+  (globalThis as any).location = { hostname: 'localhost' } as Location;
+}
+
 // Dynamic import ensures `Buffer` is available before evaluating modules that
 // depend on it (e.g. `ssb-browser-core`).
 const { getSSB } = await import('./src/instance');


### PR DESCRIPTION
## Summary
- ensure global `window` and `location` exist in the SSB worker before dynamic imports

## Testing
- `pnpm test packages/worker-ssb/__tests__`

------
https://chatgpt.com/codex/tasks/task_e_688feb4feb0c8331a555c96b1d5c509c