### PR TITLE
Fetch comments via worker

### DIFF
--- a/packages/worker-ssb/__tests__/comments.test.ts
+++ b/packages/worker-ssb/__tests__/comments.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Licensed under GPL-3.0-or-later
+ * Test suite verifying comment retrieval.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createRPCClient } from '../../../shared/rpc';
+
+vi.mock('../src/instance', () => ({
+  getSSB: () => ({
+    db: { publish: () => {} },
+    blobs: {
+      add: () => ({ write() {}, end(cb: any) { cb(null, 'hash'); } }),
+      get: vi.fn(),
+      rm: vi.fn(),
+    },
+  }),
+}));
+
+function createPortPair() {
+  const listeners1: ((ev: MessageEvent) => void)[] = [];
+  const listeners2: ((ev: MessageEvent) => void)[] = [];
+  const port1 = {
+    postMessage(data: any) {
+      listeners2.forEach((l) => l({ data } as MessageEvent));
+    },
+    addEventListener(_type: 'message', listener: (ev: MessageEvent) => void) {
+      listeners1.push(listener);
+    },
+    removeEventListener(_type: 'message', listener: (ev: MessageEvent) => void) {
+      const idx = listeners1.indexOf(listener);
+      if (idx >= 0) listeners1.splice(idx, 1);
+    },
+    start() {},
+  } as any;
+  const port2 = {
+    postMessage(data: any) {
+      listeners1.forEach((l) => l({ data } as MessageEvent));
+    },
+    addEventListener(_type: 'message', listener: (ev: MessageEvent) => void) {
+      listeners2.push(listener);
+    },
+    removeEventListener(_type: 'message', listener: (ev: MessageEvent) => void) {
+      const idx = listeners2.indexOf(listener);
+      if (idx >= 0) listeners2.splice(idx, 1);
+    },
+    start() {},
+  } as any;
+  return { port1, port2 };
+}
+
+async function setup() {
+  vi.resetModules();
+  (globalThis as any).__cashuSSBLog = [];
+  const { port1, port2 } = createPortPair();
+  (globalThis as any).self = port1;
+  await import('../index');
+  const call = createRPCClient(port2);
+  const cleanup = () => {
+    delete (globalThis as any).self;
+  };
+  return { call, cleanup };
+}
+
+describe('worker-ssb comments', () => {
+  it('returns stored comments for a post', async () => {
+    const { call, cleanup } = await setup();
+    await call('publishPost', {
+      id: 'p1',
+      author: { name: 'A', pubkey: 'a', avatarUrl: 'https://example.com/a.png' },
+      magnet: 'magnet:?xt=urn:btih:p1',
+    });
+    await call('publish', {
+      type: 'comment',
+      postId: 'p1',
+      text: 'hello',
+      ts: 1,
+    });
+    const comments = (await call('queryComments', 'p1')) as string[];
+    expect(comments).toEqual(['hello']);
+    cleanup();
+  });
+});
+

--- a/packages/worker-ssb/index.ts
+++ b/packages/worker-ssb/index.ts
@@ -113,6 +113,18 @@ createRPCHandler(self as any, {
     return fullPost;
   },
   /**
+   * Retrieve comment texts for a particular post from the local log.
+   *
+   * @param postId - Identifier of the post whose comments are requested.
+   * @returns Array of comment strings sorted by timestamp.
+   */
+  queryComments: async (postId: string) => {
+    return ssbLog
+      .filter((m) => m.type === 'comment' && m.postId === postId)
+      .sort((a, b) => (a.ts ?? 0) - (b.ts ?? 0))
+      .map((m) => m.text);
+  },
+  /**
    * Retrieve posts from the log applying basic moderation rules and tag
    * filters. Reported posts over a threshold or posts from blocked users are
    * excluded.

--- a/shared/rpc/index.ts
+++ b/shared/rpc/index.ts
@@ -35,6 +35,7 @@ const InitWalletSchema = z
 export const MethodDefinitions = {
   publishPost: z.tuple([PostSchema]),
   queryFeed: z.tuple([QueryOpts]),
+  queryComments: z.tuple([z.string()]),
   reportPost: z.tuple([z.string(), z.string()]),
   blockUser: z.tuple([z.string()]),
   publish: z.tuple([z.any()]),
@@ -53,6 +54,7 @@ export const MethodDefinitions = {
 export const MethodsSchema = z.union([
   z.object({ ns: z.literal('ssb'), fn: z.literal('publishPost'), args: MethodDefinitions.publishPost }),
   z.object({ ns: z.literal('ssb'), fn: z.literal('queryFeed'), args: MethodDefinitions.queryFeed }),
+  z.object({ ns: z.literal('ssb'), fn: z.literal('queryComments'), args: MethodDefinitions.queryComments }),
   z.object({ ns: z.literal('ssb'), fn: z.literal('reportPost'), args: MethodDefinitions.reportPost }),
   z.object({ ns: z.literal('ssb'), fn: z.literal('blockUser'), args: MethodDefinitions.blockUser }),
   z.object({ ns: z.literal('ssb'), fn: z.literal('publish'), args: MethodDefinitions.publish }),
@@ -87,6 +89,7 @@ type RPCPort = {
 const methodArgSchemas: Record<MethodName, z.ZodTypeAny> = {
   publishPost: MethodDefinitions.publishPost,
   queryFeed: MethodDefinitions.queryFeed,
+  queryComments: MethodDefinitions.queryComments,
   reportPost: MethodDefinitions.reportPost,
   blockUser: MethodDefinitions.blockUser,
   publish: MethodDefinitions.publish,

--- a/shared/ui/CommentsDrawer.tsx
+++ b/shared/ui/CommentsDrawer.tsx
@@ -4,6 +4,7 @@
  */
 import React from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
+import { createRPCClient } from '../rpc';
 
 interface CommentsDrawerProps {
   postId: string;
@@ -22,8 +23,25 @@ export const CommentsDrawer: React.FC<CommentsDrawerProps> = ({
 }) => {
   const [comments, setComments] = React.useState<string[]>([]);
   const [text, setText] = React.useState('');
+  const rpcRef = React.useRef<ReturnType<typeof createRPCClient> | null>(null);
 
-  // TODO: load comments from worker-ssb for the given postId
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const worker = new Worker(
+      new URL('../../packages/worker-ssb/index.ts', import.meta.url),
+      { type: 'module' }
+    );
+    rpcRef.current = createRPCClient(worker);
+    return () => worker.terminate();
+  }, []);
+
+  React.useEffect(() => {
+    const rpc = rpcRef.current;
+    if (!rpc || !open) return;
+    rpc('queryComments', postId)
+      .then((c) => setComments((c as string[]) || []))
+      .catch(() => setComments([]));
+  }, [postId, open]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- load comments via RPC worker in web and shared CommentsDrawer
- extend RPC schema and worker to support comment queries
- test comment retrieval from worker log

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688feff3c23c8331ae3f8acc669d2366