### PR TITLE
feat: add worker comment publishing

### DIFF
--- a/apps/web/src/components/CommentsDrawer.tsx
+++ b/apps/web/src/components/CommentsDrawer.tsx
@@ -43,13 +43,19 @@ export const CommentsDrawer: React.FC<CommentsDrawerProps> = ({
       .catch(() => setComments([]));
   }, [postId, open]);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!text.trim()) return;
+    const trimmed = text.trim();
+    if (!trimmed) return;
     // optimistic append
-    setComments((prev) => [...prev, text]);
+    setComments((prev) => [...prev, trimmed]);
     setText('');
-    // TODO: publish comment via worker-ssb
+    try {
+      await rpcRef.current?.('publishComment', { postId, text: trimmed });
+    } catch (_) {
+      // remove optimistic comment on failure
+      setComments((prev) => prev.slice(0, -1));
+    }
   };
 
   return (

--- a/packages/worker-ssb/index.ts
+++ b/packages/worker-ssb/index.ts
@@ -125,6 +125,27 @@ createRPCHandler(self as any, {
       .map((m) => m.text);
   },
   /**
+   * Append a comment for a given post to the local log.
+   *
+   * @param opts - The post identifier and comment text.
+   * @returns The stored comment with generated id and timestamp.
+   */
+  publishComment: async (opts: { postId: string; text: string }) => {
+    const comment = {
+      type: 'comment',
+      id: crypto.randomUUID(),
+      postId: opts.postId,
+      text: opts.text,
+      ts: Date.now(),
+    };
+    ssbLog.push(comment);
+    try {
+      const ssb = getSSB();
+      ssb.db.publish(comment, () => {});
+    } catch (_) {}
+    return comment;
+  },
+  /**
    * Retrieve posts from the log applying basic moderation rules and tag
    * filters. Reported posts over a threshold or posts from blocked users are
    * excluded.

--- a/shared/ui/CommentsDrawer.tsx
+++ b/shared/ui/CommentsDrawer.tsx
@@ -43,12 +43,19 @@ export const CommentsDrawer: React.FC<CommentsDrawerProps> = ({
       .catch(() => setComments([]));
   }, [postId, open]);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!text.trim()) return;
-    setComments((prev) => [...prev, text]);
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    // optimistic append
+    setComments((prev) => [...prev, trimmed]);
     setText('');
-    // TODO: publish comment via worker-ssb
+    try {
+      await rpcRef.current?.('publishComment', { postId, text: trimmed });
+    } catch (_) {
+      // remove optimistic comment on failure
+      setComments((prev) => prev.slice(0, -1));
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- add `publishComment` RPC in worker to append comments to log
- call `publishComment` from comments drawers with optimistic updates and error rollback

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688ff1e97150833183b270231849211d