### PR TITLE
Ensure import option visible on onboarding

### DIFF
--- a/apps/web/src/routes/Onboarding.test.tsx
+++ b/apps/web/src/routes/Onboarding.test.tsx
@@ -89,10 +89,14 @@ describe('Onboarding steps', () => {
       root.render(<Onboarding />);
     });
 
-      expect(container.textContent).toContain('New Account');
-      const newBtn = Array.from(container.querySelectorAll('button')).find(
-        (b) => b.textContent?.includes('New Account'),
-      )!;
+    expect(container.textContent).toContain('New Account');
+    expect(container.textContent).toContain('Import Existing Profile');
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const newBtn = buttons.find((b) => b.textContent?.includes('New Account'))!;
+    const importBtn = buttons.find((b) =>
+      b.textContent?.includes('Import Existing Profile'),
+    );
+    expect(importBtn).toBeTruthy();
     await act(async () => {
       newBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
@@ -104,9 +108,9 @@ describe('Onboarding steps', () => {
     await act(async () => {
       root.render(<Onboarding />);
     });
-      const importBtn = Array.from(container.querySelectorAll('button')).find(
-        (b) => b.textContent?.includes('Import Existing Profile'),
-      )!;
+    const importBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent?.includes('Import Existing Profile'),
+    )!;
     await act(async () => {
       importBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });

--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -213,6 +213,7 @@ function OnboardingContent() {
               setMode('import');
               setStep(2);
             }}
+            aria-label="Import Existing Profile"
           >
             <Upload className="h-5 w-5" />
             <div className="text-left">


### PR DESCRIPTION
## Summary
- make import profile button explicitly labeled and always present
- test that new and import actions are shown on initial onboarding step

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688ff215cbd48331b454bc03c72cda27