### PR TITLE
Preserve onboarding step across remounts

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { ROUTES } from './router';
 import { useProfile } from '../shared/store/profile';
-import Onboarding from './routes/Onboarding';
+import { OnboardingDialog } from './routes/Onboarding';
 import SearchBar from './components/SearchBar';
 
 export default function App() {
@@ -18,15 +18,12 @@ export default function App() {
     return () => window.removeEventListener('popstate', onPopState);
   }, []);
 
-  if (!profile?.ssbPk) {
-    return <Onboarding />;
-  }
-
   const RouteComponent = ROUTES[path];
   return (
     <>
       {RouteComponent ? <RouteComponent /> : <div>Not Found</div>}
-      <SearchBar />
+      {profile?.ssbPk && <SearchBar />}
+      <OnboardingDialog />
     </>
   );
 }

--- a/apps/web/src/routes/Onboarding.test.tsx
+++ b/apps/web/src/routes/Onboarding.test.tsx
@@ -29,7 +29,7 @@ vi.mock('react-dropzone', () => ({
   },
 }));
 
-import Onboarding from './Onboarding';
+import Onboarding, { resetOnboardingState } from './Onboarding';
 import { useProfile } from '../../shared/store/profile';
 
 class MockWorker {
@@ -80,6 +80,7 @@ beforeEach(() => {
   useProfile.setState({ profile: undefined });
   document.body.innerHTML = '';
   dropHandlers.length = 0;
+  resetOnboardingState();
 });
 
 describe('Onboarding steps', () => {
@@ -116,6 +117,23 @@ describe('Onboarding steps', () => {
     });
     expect(container.textContent).toContain('Profile Backup');
     expect(container.textContent).toContain('Wallet Backup');
+  });
+
+  it('stays on step 2 after selecting New Account', async () => {
+    const { container, root } = setupDom();
+    await act(async () => {
+      root.render(<Onboarding />);
+    });
+    const newBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('New Account'),
+    )!;
+    await act(async () => {
+      newBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    // wait to ensure no unmount occurs after async effects
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(container.textContent).toContain('Profile Details');
   });
 
   it(
@@ -221,6 +239,7 @@ describe('Onboarding steps', () => {
     // profile file dropped into wallet zone
     {
       dropHandlers.length = 0;
+      resetOnboardingState();
       const { container, root } = setupDom();
       await act(async () => {
         root.render(<Onboarding />);

--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -27,10 +27,24 @@ const WalletBackupSchema = z.object({
   cashuMnemonic: z.string(),
 });
 
+// persist step and mode across unmounts triggered by parent rerenders
+const stepRef = { current: 1 };
+const modeRef = { current: null as 'new' | 'import' | null };
+
 function OnboardingContent() {
-  const [step, setStep] = useState(1);
-  const [mode, setMode] = useState<'new' | 'import' | null>(null);
+  const [step, setStepState] = useState(stepRef.current);
+  const [mode, setModeState] = useState<'new' | 'import' | null>(modeRef.current);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  // wrappers to keep refs updated alongside state
+  const setStep = (n: number) => {
+    stepRef.current = n;
+    setStepState(n);
+  };
+  const setMode = (m: 'new' | 'import' | null) => {
+    modeRef.current = m;
+    setModeState(m);
+  };
 
   useEffect(() => {
     const first = containerRef.current?.querySelector<HTMLElement>(
@@ -597,4 +611,10 @@ export function OnboardingDialog() {
       </Dialog.Content>
     </Dialog.Root>
   );
+}
+
+// helper for tests to reset persistent onboarding progress
+export function resetOnboardingState() {
+  stepRef.current = 1;
+  modeRef.current = null;
 }


### PR DESCRIPTION
## Summary
- persist onboarding step/mode across parent re-renders and expose reset helper
- render onboarding dialog alongside app to avoid transient unmounts
- add regression test ensuring new account flow stays on step 2

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688ff37d950c8331ab9e7254a749719c