### PR TITLE
Render onboarding flow before profile setup

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,11 +5,16 @@
 import React from 'react';
 import { ROUTES } from './router';
 import { useProfile } from '../shared/store/profile';
-import { OnboardingDialog } from './routes/Onboarding';
+import Onboarding from './routes/Onboarding';
 import SearchBar from './components/SearchBar';
 
 export default function App() {
-  const profile = useProfile((s) => s.profile);
+  const { profile } = useProfile();
+
+  if (!profile?.ssbPk) {
+    return <Onboarding />;
+  }
+
   const [path, setPath] = React.useState(() => window.location.pathname);
 
   React.useEffect(() => {
@@ -23,7 +28,6 @@ export default function App() {
     <>
       {RouteComponent ? <RouteComponent /> : <div>Not Found</div>}
       {profile?.ssbPk && <SearchBar />}
-      <OnboardingDialog />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Show the full `Onboarding` component when no profile is configured
- Remove obsolete `OnboardingDialog` usage in `App`

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688ff845bbd48331a0efc1d2856bba1d