### PR TITLE
Wrap onboarding dialog in portal and remove unused export

### DIFF
--- a/apps/web/src/routes/Onboarding.test.tsx
+++ b/apps/web/src/routes/Onboarding.test.tsx
@@ -44,10 +44,11 @@ class MockWorker {
 }
 
 const setupDom = () => {
-  const container = document.createElement('div');
-  document.body.appendChild(container);
-  const root = createRoot(container);
-  return { container, root };
+  document.body.innerHTML = '';
+  const rootContainer = document.createElement('div');
+  document.body.appendChild(rootContainer);
+  const root = createRoot(rootContainer);
+  return { container: document.body, root };
 };
 
 const mockStorage = () => {

--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -583,36 +583,18 @@ function OnboardingContent() {
 export default function Onboarding() {
   return (
     <Dialog.Root open defaultOpen>
-      <Dialog.Overlay className="fixed inset-0 bg-black/50 z-40" />
-      <Dialog.Content className="fixed inset-0 flex items-center justify-center z-50 p-4">
-        <Dialog.Title className="sr-only">Onboarding</Dialog.Title>
-        <Dialog.Description className="sr-only">
-          Set up your profile to start using CashuCast
-        </Dialog.Description>
-        <div className="bg-white rounded-xl p-6 w-full max-w-md">
-          <OnboardingContent />
-        </div>
-      </Dialog.Content>
-    </Dialog.Root>
-  );
-}
-
-export function OnboardingDialog() {
-  const profile = useProfile((s) => s.profile);
-  const [open, setOpen] = useState(!profile);
-  useEffect(() => setOpen(!profile), [profile]);
-  return (
-    <Dialog.Root open={open} onOpenChange={setOpen}>
-      <Dialog.Overlay className="fixed inset-0 bg-black/50 z-40" />
-      <Dialog.Content className="fixed inset-0 flex items-center justify-center z-50 p-4">
-        <Dialog.Title className="sr-only">Onboarding</Dialog.Title>
-        <Dialog.Description className="sr-only">
-          Set up your profile to start using CashuCast
-        </Dialog.Description>
-        <div className="bg-white rounded-xl p-6 w-full max-w-md">
-          <OnboardingContent />
-        </div>
-      </Dialog.Content>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-[99]" />
+        <Dialog.Content className="fixed inset-0 flex items-center justify-center z-[100] p-4">
+          <Dialog.Title className="sr-only">Onboarding</Dialog.Title>
+          <Dialog.Description className="sr-only">
+            Set up your profile to start using CashuCast
+          </Dialog.Description>
+          <div className="bg-white rounded-xl p-6 w-full max-w-md">
+            <OnboardingContent />
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
     </Dialog.Root>
   );
 }


### PR DESCRIPTION
## Summary
- ensure Onboarding dialog renders via `Dialog.Portal` and overlay uses high z-index
- remove unused `OnboardingDialog` export
- update Onboarding tests for portal rendering

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688ffbb0edf8833191a82a3bf911fd45