### PR TITLE
chore: include tagify css in tag input

### DIFF
--- a/apps/web/src/components/TagInput.tsx
+++ b/apps/web/src/components/TagInput.tsx
@@ -3,6 +3,7 @@
  * React component for TagInput.
  */
 /* wraps Tagify; lower-cases, strips leading #, max 10 tags */
+import '@yaireo/tagify/dist/tagify.css';
 import Tags from '@yaireo/tagify/dist/react.tagify';
 
 export default function TagInput({


### PR DESCRIPTION
## Summary
- include Tagify's CSS in TagInput component

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6890080354908331a2e0784886dbacd5