### PR TITLE
Allow profile import with single backup

### DIFF
--- a/apps/web/src/routes/Onboarding.test.tsx
+++ b/apps/web/src/routes/Onboarding.test.tsx
@@ -163,7 +163,7 @@ describe('Onboarding steps', () => {
   });
 
   it(
-    'shows profile success message when dropping valid profile backup and enables Next after wallet backup',
+    'shows profile success message and enables Next with profile or wallet backup',
     async () => {
       const { container, root } = setupDom();
       await act(async () => {
@@ -191,7 +191,7 @@ describe('Onboarding steps', () => {
       const nextBtn = Array.from(container.querySelectorAll('button')).find(
         (b) => b.textContent === 'Next',
       )!;
-      expect(nextBtn.disabled).toBe(true);
+      expect(nextBtn.disabled).toBe(false);
       const walletFile = {
         text: () => Promise.resolve(JSON.stringify({ cashuMnemonic: 'mnemonic' })),
       } as any;
@@ -229,7 +229,7 @@ describe('Onboarding steps', () => {
     const nextBtn = Array.from(container.querySelectorAll('button')).find(
       (b) => b.textContent === 'Next',
     )!;
-    expect(nextBtn.disabled).toBe(true);
+    expect(nextBtn.disabled).toBe(false);
   });
 
   it('misplacing backups shows errors without affecting other drop zone', async () => {

--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -521,14 +521,14 @@ function OnboardingContent() {
           <button
             className="rounded bg-blue-700 hover:bg-blue-800 text-white px-4 py-3 min-w-[44px] min-h-[44px]"
             onClick={() => {
-              if (!profileBackup || !walletBackup) return;
+              if (mode !== 'import' || (!profileBackup && !walletBackup)) return;
               const profileData: any = { ...profileBackup };
-              profileData.cashuMnemonic = walletBackup.cashuMnemonic;
+              if (walletBackup) profileData.cashuMnemonic = walletBackup.cashuMnemonic;
               importProfile(profileData);
               setStep(3);
             }}
             disabled={
-              !(profileBackup && walletBackup && !profileError && !walletError) ||
+              !((profileBackup || walletBackup) && !profileError && !walletError) ||
               profileLoading ||
               walletLoading
             }


### PR DESCRIPTION
## Summary
- Prevent profile import unless the onboarding mode is `import` and at least one backup is present
- Enable advancing with either a profile or wallet backup file
- Adjust onboarding tests for single-backup support

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689009b4b9748331930abf4922b9d0b0