### PR TITLE
chore: alias random-access-idb and stub fs in worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,10 @@
     "jsdom": "^26.1.0",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"
+  },
+  "pnpm": {
+    "overrides": {
+      "random-access-chrome-file": "npm:random-access-idb@^1.2.2"
+    }
   }
 }

--- a/packages/worker-ssb/empty-fs.js
+++ b/packages/worker-ssb/empty-fs.js
@@ -1,0 +1,7 @@
+/*
+ * Licensed under GPL-3.0-or-later
+ * empty-fs module.
+ */
+export const readFile = () => {
+  throw new Error('fs.readFile is not available in the browser');
+};

--- a/packages/worker-ssb/vite.config.ts
+++ b/packages/worker-ssb/vite.config.ts
@@ -1,0 +1,15 @@
+/*
+ * Licensed under GPL-3.0-or-later
+ * Vite config for worker-ssb.
+ */
+import { defineConfig } from 'vite';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      // Stub fs to prevent node filesystem access in the worker bundle
+      fs: path.resolve(__dirname, 'empty-fs.js'),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  random-access-chrome-file: npm:random-access-idb@^1.2.2
+
 importers:
 
   .:
@@ -2737,9 +2740,6 @@ packages:
   randexp@0.4.6:
     resolution: {integrity: sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==}
     engines: {node: '>=0.12'}
-
-  random-access-chrome-file@1.2.0:
-    resolution: {integrity: sha512-M1NOdkHEcjRB+acKrdQkwf8aMTnZUIGboiH6i2PMNkjfChBIJiB4j4MuhpOn+u+XU2n7GqpocPN4bzfv0jrBsg==}
 
   random-access-file@2.2.1:
     resolution: {integrity: sha512-RGU0xmDqdOyEiynob1KYSeh8+9c9Td1MJ74GT1viMEYAn8SJ9oBtWCXLsYZukCF46yududHOdM449uRYbzBrZQ==}
@@ -6416,10 +6416,6 @@ snapshots:
       discontinuous-range: 1.0.0
       ret: 0.1.15
 
-  random-access-chrome-file@1.2.0:
-    dependencies:
-      random-access-storage: 1.4.3
-
   random-access-file@2.2.1:
     dependencies:
       mkdirp-classic: 0.5.3
@@ -6458,7 +6454,7 @@ snapshots:
   random-access-web@2.0.3:
     dependencies:
       '@sammacbeth/random-access-idb-mutable-file': 0.1.1
-      random-access-chrome-file: 1.2.0
+      random-access-chrome-file: random-access-idb@1.2.2
       random-access-idb: 1.2.2
       random-access-idb-mutable-file: 0.3.0
       random-access-memory: 3.1.4


### PR DESCRIPTION
## Summary
- alias `random-access-chrome-file` to `random-access-idb` via PNPM override
- add worker Vite config stubbing `fs` to an empty module

## Testing
- `pnpm install --lockfile-only`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68900af81d908331be533a0662f21b5a