### PR TITLE
Render onboarding dialog when no profile

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,8 +10,9 @@ import SearchBar from './components/SearchBar';
 
 export default function App() {
   const { profile } = useProfile();
+  const hasProfile = Boolean(profile?.ssbPk);
 
-  if (!profile?.ssbPk) {
+  if (!hasProfile) {
     return <Onboarding />;
   }
 
@@ -24,10 +25,11 @@ export default function App() {
   }, []);
 
   const RouteComponent = ROUTES[path];
+
   return (
     <>
       {RouteComponent ? <RouteComponent /> : <div>Not Found</div>}
-      {profile?.ssbPk && <SearchBar />}
+      <SearchBar />
     </>
   );
 }

--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -588,10 +588,10 @@ function OnboardingContent() {
 
 export default function Onboarding() {
   return (
-    <Dialog.Root open defaultOpen>
+    <Dialog.Root open>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-[99]" />
-        <Dialog.Content className="fixed inset-0 flex items-center justify-center z-50 p-4">
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-40" />
+        <Dialog.Content className="fixed inset-0 flex items-center justify-center z-50">
           <Dialog.Title className="sr-only">Onboarding</Dialog.Title>
           <Dialog.Description className="sr-only">
             Set up your profile to start using CashuCast


### PR DESCRIPTION
## Summary
- show onboarding dialog whenever no SSB key exists
- overlay onboarding in a Radix Dialog portal

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68900f30d2dc83318a252e99294c89d7