### PR TITLE
Load react-easy-crop default styles

### DIFF
--- a/apps/web/src/components/ThumbnailPicker.tsx
+++ b/apps/web/src/components/ThumbnailPicker.tsx
@@ -4,6 +4,7 @@
  */
 import { useState, useEffect, useCallback } from 'react';
 import Cropper from 'react-easy-crop';
+import 'react-easy-crop/react-easy-crop.css';
 import { FFmpeg } from '@ffmpeg/ffmpeg';
 import Dropzone from 'react-dropzone';
 import { getSSB } from '../../../../packages/worker-ssb/src/instance';

--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -14,6 +14,7 @@ import { touch } from '../../../../packages/worker-ssb/src/blobCache';
 import { z } from 'zod';
 import { UserPlus, Upload, DownloadCloud } from 'lucide-react';
 import { Avatar } from '../../shared/ui/Avatar';
+import 'react-easy-crop/react-easy-crop.css';
 
 // schemas for validating imported backups
 const ProfileBackupSchema = z.object({


### PR DESCRIPTION
## Summary
- ensure react-easy-crop default styles are loaded for ThumbnailPicker and Onboarding components

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6890128de48483318c5f91faee633738