### PR TITLE
web: pass post objects to TimelineCard

### DIFF
--- a/apps/web/src/routes/Discover.tsx
+++ b/apps/web/src/routes/Discover.tsx
@@ -50,20 +50,22 @@ export default function Discover() {
         ))}
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        {posts.map((post) => (
-          <TimelineCard
-            key={post.id}
-            name={post.author.name}
-            avatarUrl={post.author.avatarUrl}
-            text={post.text}
-            magnet={post.magnet}
-            nsfw={post.nsfw}
-            postId={post.id}
-            authorPubKey={post.author.pubkey}
-            reports={post.reports?.length ?? 0}
-            boosters={post.boosters}
-          />
-        ))}
+        {posts.map((post) => {
+          const timelinePost = {
+            id: post.id,
+            authorAvatar: post.author.avatarUrl,
+            authorName: post.author.name,
+            description: post.text,
+            magnet: post.magnet,
+            nsfw: post.nsfw,
+            authorPubKey: post.author.pubkey,
+            reports: post.reports?.length ?? 0,
+            zaps: (post as any).zaps ?? 0,
+            comments: (post as any).comments ?? 0,
+            boosters: post.boosters ?? [],
+          };
+          return <TimelineCard key={post.id} post={timelinePost} />;
+        })}
       </div>
     </div>
   );

--- a/apps/web/src/routes/SearchResults.tsx
+++ b/apps/web/src/routes/SearchResults.tsx
@@ -13,20 +13,22 @@ export default function SearchResults() {
       {results.length === 0 ? (
         <div>No matches.</div>
       ) : (
-        results.map((post) => (
-          <TimelineCard
-            key={post.id}
-            name={post.author.name}
-            avatarUrl={post.author.avatarUrl}
-            text={post.text}
-            magnet={post.magnet}
-            nsfw={post.nsfw}
-            postId={post.id}
-            authorPubKey={post.author.pubkey}
-            reports={post.reports?.length ?? 0}
-            boosters={post.boosters}
-          />
-        ))
+        results.map((post) => {
+          const timelinePost = {
+            id: post.id,
+            authorAvatar: post.author.avatarUrl,
+            authorName: post.author.name,
+            description: post.text,
+            magnet: post.magnet,
+            nsfw: post.nsfw,
+            authorPubKey: post.author.pubkey,
+            reports: post.reports?.length ?? 0,
+            zaps: (post as any).zaps ?? 0,
+            comments: (post as any).comments ?? 0,
+            boosters: post.boosters ?? [],
+          };
+          return <TimelineCard key={post.id} post={timelinePost} />;
+        })
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- refactor Discover and SearchResults routes to pass `post` objects into `TimelineCard`
- normalize post fields (author avatar/name, description, stats) before rendering

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68901b7328888331bdba4adf5334acbc