### PR TITLE
fix: keep avatar placeholder visible

### DIFF
--- a/apps/web/src/routes/Onboarding.test.tsx
+++ b/apps/web/src/routes/Onboarding.test.tsx
@@ -162,6 +162,23 @@ describe('Onboarding steps', () => {
     expect(container.textContent).toContain('Profile Details');
   });
 
+  it('displays avatar placeholder before selecting an image', async () => {
+    const { container, root } = setupDom();
+    await act(async () => {
+      root.render(<Onboarding />);
+    });
+    const newBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('New Account'),
+    )!;
+    await act(async () => {
+      newBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const avatarSpan = container.querySelector(
+      '[aria-describedby="avatar-upload-caption"] .rounded-full span',
+    );
+    expect(avatarSpan?.textContent).toBe('P');
+  });
+
   it(
     'shows profile success message and enables Next with profile or wallet backup',
     async () => {

--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -307,11 +307,11 @@ function OnboardingContent() {
                 <Avatar
                   name="Placeholder"
                   size={128}
-                  className="border"
+                  className="border z-0"
                 />
                   <div
                     aria-hidden="true"
-                    className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center bg-white/75 text-gray-500"
+                    className="pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center bg-white/60 text-gray-500"
                   >
                     <Upload className="h-6 w-6 mb-1" />
                     <span className="text-xs text-center px-1">


### PR DESCRIPTION
## Summary
- keep avatar placeholder visible under upload prompt by adjusting overlay z-index and opacity
- test onboarding shows placeholder before selecting an image

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689038e081f48331b1144186afe26b4e