### PR TITLE
test: verify onboarding buttons use primary color

### DIFF
--- a/apps/web/playwright/onboarding.pw.tsx
+++ b/apps/web/playwright/onboarding.pw.tsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import { test, expect } from '@playwright/experimental-ct-react';
-import Onboarding from '../src/routes/Onboarding';
+import Onboarding, { resetOnboardingState } from '../src/routes/Onboarding';
 import { useProfile } from '../shared/store/profile';
 
 test('onboarding new account flow', async ({ mount, page }) => {
@@ -40,5 +40,17 @@ test('onboarding new account flow', async ({ mount, page }) => {
   await page.fill('input[placeholder="Username"]', 'alice');
   await component.getByText('Confirm').click();
   await expect(page).toHaveURL('/');
+});
+
+test('onboarding step-1 buttons have primary background color', async ({ mount }) => {
+  resetOnboardingState();
+  useProfile.setState({ profile: undefined });
+  const component = await mount(<Onboarding />);
+  const newAccount = component.getByRole('button', { name: 'New Account' });
+  await expect(newAccount).toHaveCSS('background-color', 'rgb(255, 7, 89)');
+  const importExisting = component.getByRole('button', {
+    name: 'Import Existing',
+  });
+  await expect(importExisting).toHaveCSS('background-color', 'rgb(255, 7, 89)');
 });
 


### PR DESCRIPTION
## Summary
- ensure onboarding test imports reset helper
- add Playwright test confirming onboarding buttons use primary color

## Testing
- `npx playwright test` *(fails: ReferenceError: exports is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68903848169483319bd449c06a5cef38