### PR TITLE
fix onboarding avatar cropper sizing

### DIFF
--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -327,7 +327,8 @@ function OnboardingContent() {
             )}
           {avatarSrc && !avatarPreview && (
             <div className="flex flex-col items-center">
-              <div className="relative w-full max-w-xs aspect-square bg-gray-200 mb-4">
+              {/* Explicit sizing ensures Cropper renders correctly */}
+              <div className="relative w-64 h-64 bg-gray-200 mb-4">
                 <Cropper
                   image={avatarSrc}
                   crop={crop}


### PR DESCRIPTION
## Summary
- ensure react-easy-crop styles load
- give avatar cropper a fixed 256px square so it displays properly

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68903fc45b2c8331967594b86ce338b1