### PR TITLE
feat: move action column to timeline card

### DIFF
--- a/apps/web/src/components/ActionColumn.tsx
+++ b/apps/web/src/components/ActionColumn.tsx
@@ -27,7 +27,7 @@ declare function openComments(post: any): void;
 export default function ActionColumn({ post }: { post: any }) {
   const { zaps, comments, boosters } = post;
   return (
-    <div className="absolute bottom-28 right-3 z-20 flex flex-col items-center gap-4 text-white">
+    <div className="absolute bottom-20 right-4 z-20 flex flex-col items-center gap-4 text-white">
       <button
         aria-label="Boost"
         onClick={() => workerSsb.publish({ type: 'repost', link: post.id })}


### PR DESCRIPTION
## Summary
- place ActionColumn in TimelineCard bottom-right overlay
- refactor TimelineCard to accept full post object
- tweak ActionColumn position to match design

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68903fda1db08331b65b3e6ba491f7f7