### PR TITLE
Trigger key generation on confirmation step

### DIFF
--- a/apps/web/src/routes/Onboarding.test.tsx
+++ b/apps/web/src/routes/Onboarding.test.tsx
@@ -156,10 +156,8 @@ describe('Onboarding steps', () => {
     await act(async () => {
       newBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
-    // wait to ensure no unmount occurs after async effects
-    await new Promise((r) => setTimeout(r, 0));
-    await new Promise((r) => setTimeout(r, 0));
     expect(container.textContent).toContain('Profile Details');
+    expect(container.textContent).not.toContain('Loading...');
   });
 
   it('displays avatar placeholder before selecting an image', async () => {


### PR DESCRIPTION
## Summary
- Move key/mnemonic generation into a `generateKeysAndMnemonic` handler invoked on "Next"
- Only show the "Loading..." message after generation begins
- Adjust onboarding tests for the new generation trigger

## Testing
- `pnpm lint apps/web/src/routes/Onboarding.tsx apps/web/src/routes/Onboarding.test.tsx`
- `pnpm test apps/web/src/routes/Onboarding.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689049174af08331957d33cfc303f0dc