### PR TITLE
Allow cancelling onboarding

### DIFF
--- a/apps/web/src/routes/Onboarding.test.tsx
+++ b/apps/web/src/routes/Onboarding.test.tsx
@@ -160,6 +160,26 @@ describe('Onboarding steps', () => {
     expect(container.textContent).not.toContain('Loading...');
   });
 
+  it('allows cancelling to restart onboarding', async () => {
+    const { container, root } = setupDom();
+    await act(async () => {
+      root.render(<Onboarding />);
+    });
+    const newBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('New Account'),
+    )!;
+    await act(async () => {
+      newBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const cancelBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Cancel',
+    )!;
+    await act(async () => {
+      cancelBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.textContent).toContain('Step 1 of 3');
+  });
+
   it('displays avatar placeholder before selecting an image', async () => {
     const { container, root } = setupDom();
     await act(async () => {

--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -196,7 +196,21 @@ function OnboardingContent() {
       <div aria-live="polite" className="sr-only">
         {stepTitle}
       </div>
-      <div className="text-sm text-gray-500">Step {step} of 3</div>
+      <div className="flex justify-between items-center text-sm text-gray-500">
+        <span>Step {step} of 3</span>
+        {step > 1 && (
+          <button
+            type="button"
+            onClick={() => {
+              setStep(1);
+              setMode(null);
+            }}
+            className="hover:underline"
+          >
+            Cancel
+          </button>
+        )}
+      </div>
       {step === 1 && (
         <div className="flex flex-col gap-4">
           <h2 className="text-xl font-semibold">Choose how to get started</h2>
@@ -364,7 +378,6 @@ function OnboardingContent() {
             <button
               className="rounded bg-gray-700 hover:bg-gray-800 text-white px-4 py-3 min-w-[44px] min-h-[44px]"
               onClick={() => setStep(1)}
-              disabled={generating}
             >
               Back
             </button>


### PR DESCRIPTION
## Summary
- keep the Back button active during profile creation
- add a Cancel control to reset onboarding progress
- test onboarding cancellation flow

## Testing
- `pnpm lint`
- `pnpm test apps/web/src/routes/Onboarding.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68904b7a1cdc8331b14abc35c7138c04