### PR TITLE
feat: reuse FabRecord in timeline card

### DIFF
--- a/apps/web/playwright/fabRecord.pw.tsx
+++ b/apps/web/playwright/fabRecord.pw.tsx
@@ -9,7 +9,7 @@ import FabRecord from '../../shared/ui/FabRecord';
 // Short tap should navigate to /record
 
 test('short tap navigates to /record', async ({ mount, page }) => {
-  await mount(<FabRecord />);
+  await mount(<FabRecord className="absolute bottom-4 left-1/2" />);
   await page.getByRole('button', { name: 'Record' }).click();
   await expect(page).toHaveURL('/record');
 });
@@ -17,7 +17,7 @@ test('short tap navigates to /record', async ({ mount, page }) => {
 // Long press should open file selector and navigate to /compose
 
 test('long press opens file selector and navigates to /compose', async ({ mount, page }) => {
-  await mount(<FabRecord />);
+  await mount(<FabRecord className="absolute bottom-4 left-1/2" />);
   const button = page.getByRole('button', { name: 'Record' });
   await button.dispatchEvent('mousedown');
   await page.waitForTimeout(600);

--- a/apps/web/src/components/TimelineCard.test.tsx
+++ b/apps/web/src/components/TimelineCard.test.tsx
@@ -40,7 +40,9 @@ vi.mock('../../shared/ui', async () => {
     ),
     BottomSheet: ({ open, children }: any) => (open ? <div role="dialog">{children}</div> : null),
     Profile: ({ name }: { name: string }) => <div>Profile-{name}</div>,
-    FabRecord: () => <button aria-label="Record" />,
+    FabRecord: ({ className }: { className?: string }) => (
+      <button aria-label="Record" className={className} />
+    ),
   };
 });
 

--- a/apps/web/src/components/TimelineCard.tsx
+++ b/apps/web/src/components/TimelineCard.tsx
@@ -126,7 +126,7 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({ post }) => {
             <div className="bg-gradient-to-t from-black/70 p-4 pointer-events-auto">{text}</div>
           )}
         </div>
-        <FabRecord />
+        <FabRecord className="absolute bottom-4 left-1/2 -translate-x-1/2 pointer-events-auto" />
       </motion.article>
       {postId && (
         <CommentsDrawer

--- a/shared/ui/FabRecord.tsx
+++ b/shared/ui/FabRecord.tsx
@@ -4,7 +4,12 @@
  */
 import React, { useRef } from 'react';
 
-const FabRecord: React.FC = () => {
+export interface FabRecordProps {
+  /** Optional positioning classes for the button */
+  className?: string;
+}
+
+const FabRecord: React.FC<FabRecordProps> = ({ className }) => {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressRef = useRef(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -38,6 +43,9 @@ const FabRecord: React.FC = () => {
     }
   };
 
+  const positionClass =
+    className ?? 'fixed bottom-16 left-1/2 -translate-x-1/2';
+
   return (
     <>
       <button
@@ -47,7 +55,7 @@ const FabRecord: React.FC = () => {
         onTouchEnd={endPress}
         onMouseLeave={endPress}
         aria-label="Record"
-        className="fixed bottom-16 left-1/2 -translate-x-1/2 z-50 flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-r from-[#FF0759] to-[#FF8A90] text-white drop-shadow-lg motion-safe:hover:scale-105 sm:hidden"
+        className={`${positionClass} z-50 flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-r from-[#FF0759] to-[#FF8A90] text-white drop-shadow-lg motion-safe:hover:scale-105 sm:hidden`}
       >
         +
       </button>


### PR DESCRIPTION
## Summary
- allow FabRecord to accept custom positioning classes
- embed FabRecord in TimelineCard with absolute positioning
- adjust FabRecord tests to cover custom placement

## Testing
- `pnpm test`
- `npx playwright test apps/web/playwright/fabRecord.pw.tsx` (fails: Test timeout of 30000ms exceeded)


------
https://chatgpt.com/codex/tasks/task_e_68904c0ef7f0833197031027e7456aa1