### PR TITLE
refactor: centralize worker rpc in TimelineCard

### DIFF
--- a/apps/web/src/components/ActionColumn.test.tsx
+++ b/apps/web/src/components/ActionColumn.test.tsx
@@ -10,7 +10,10 @@ import ActionColumn from './ActionColumn';
 describe('ActionColumn', () => {
   it('renders three action buttons with counts', () => {
     const post = { id: 'p1', zaps: 5, comments: 7, boosters: ['a', 'b', 'c'] };
-    const result = renderToString(<ActionColumn post={post} />);
+    const rpc = (() => Promise.resolve()) as any;
+    const result = renderToString(
+      <ActionColumn post={post} rpc={rpc} onOpenComments={() => {}} />
+    );
     const clean = result.replace(/<!--.*?-->/g, '');
     expect(clean).toContain('aria-label="Boost"');
     expect(clean).toContain('aria-label="Zap"');

--- a/apps/web/src/components/TimelineCard.test.tsx
+++ b/apps/web/src/components/TimelineCard.test.tsx
@@ -21,7 +21,7 @@ vi.mock('../../shared/rpc', () => ({
 }));
 
 vi.mock('./CommentsDrawer', () => ({
-  CommentsDrawer: ({ open }: { open: boolean }) =>
+  CommentsDrawer: ({ open }: { open: boolean; rpc?: any }) =>
     open ? <div role="dialog">Comments</div> : null,
 }));
 

--- a/apps/web/src/components/TimelineCard.tsx
+++ b/apps/web/src/components/TimelineCard.tsx
@@ -57,27 +57,10 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({ post }) => {
       { type: 'module' }
     );
     rpcRef.current = createRPCClient(worker);
-
-    const globals = globalThis as any;
-    globals.workerSsb = {
-      publish: (data: any) => rpcRef.current?.('publish', data),
-    };
-    globals.zap = (p: any) => {
-      if (authorPubKey) {
-        rpcRef.current?.('sendZap', authorPubKey, 1, p.id);
-      }
-    };
-    globals.openComments = (p: any) => {
-      if (p.id === postId) setCommentsOpen(true);
-    };
-
     return () => {
       worker.terminate();
-      delete globals.workerSsb;
-      delete globals.zap;
-      delete globals.openComments;
     };
-  }, [postId, authorPubKey]);
+  }, []);
 
   const reveal = () => setRevealed(true);
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -96,7 +79,13 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({ post }) => {
         transition={{ duration: 0.4 }}
       >
         <VideoPlayer magnet={magnet} postId={postId} />
-        {postId && <ActionColumn post={post} />}
+        {postId && (
+          <ActionColumn
+            post={post}
+            rpc={rpcRef.current}
+            onOpenComments={() => setCommentsOpen(true)}
+          />
+        )}
         {hidden && (
           <BlurOverlay
             aria-label="NSFW content hidden"
@@ -133,6 +122,7 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({ post }) => {
           postId={postId}
           open={commentsOpen}
           onOpenChange={setCommentsOpen}
+          rpc={rpcRef.current}
         />
       )}
       {authorPubKey && (


### PR DESCRIPTION
## Summary
- pass worker RPC client from TimelineCard to ActionColumn and CommentsDrawer
- remove per-component worker setup for comments
- clean up worker on TimelineCard unmount

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6890511327b083319377f2c72806104a