### PR TITLE
chore: remove unused tailwind keyframes

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -17,16 +17,6 @@ module.exports = {
         surface:  '#121212',
         subtleBg:'#1F1F1F',
       },
-      keyframes: {
-        fadeUp: {
-          from: { opacity: '0', transform: 'translateY(0.5rem)' },
-          to: { opacity: '1', transform: 'translateY(0)' },
-        },
-        slideLeft: {
-          from: { transform: 'translateX(100%)' },
-          to: { transform: 'translateX(0)' },
-        },
-      },
       transitionTimingFunction: {
         ez: 'cubic-bezier(0.25,0.1,0.25,1)',
       },


### PR DESCRIPTION
## Summary
- remove `fadeUp` and `slideLeft` keyframes from Tailwind config

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter web build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6890555d960c8331ba4ca0856e30c7f0