### PR TITLE
feat: add reusable toast component

### DIFF
--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -14,6 +14,7 @@ import { touch } from '../../../../packages/worker-ssb/src/blobCache';
 import { z } from 'zod';
 import { UserPlus, Upload, DownloadCloud } from 'lucide-react';
 import { Avatar } from '../../shared/ui/Avatar';
+import { Toast } from '../../shared/ui/Toast';
 import 'react-easy-crop/react-easy-crop.css';
 
 // schemas for validating imported backups
@@ -613,13 +614,11 @@ function OnboardingContent() {
         </div>
       )}
       {toast && (
-        <div
-          className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-gray-800 text-white px-4 py-2 rounded"
-          role="status"
-          aria-live="assertive"
-        >
-          Welcome to CashuCast!
-        </div>
+        <Toast
+          message="Welcome to CashuCast!"
+          duration={1000}
+          onHide={() => setToast(false)}
+        />
       )}
     </div>
   );

--- a/shared/ui/PublishBtn.tsx
+++ b/shared/ui/PublishBtn.tsx
@@ -3,6 +3,7 @@
  * React component for PublishBtn.
  */
 import React from 'react';
+import { Toast } from './Toast';
 
 /**
  * PublishBtn remains disabled until a magnet link is provided.
@@ -18,7 +19,6 @@ export const PublishBtn: React.FC<PublishBtnProps> = ({ magnet, onPublish }) => 
   const handleClick = async () => {
     await onPublish();
     setShow(true);
-    setTimeout(() => setShow(false), 3000);
   };
 
   return (
@@ -31,9 +31,10 @@ export const PublishBtn: React.FC<PublishBtnProps> = ({ magnet, onPublish }) => 
         Publish
       </button>
       {show && (
-        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-gray-800 text-white px-4 py-2 rounded">
-          Posted! Your followers will sync when online
-        </div>
+        <Toast
+          message="Posted! Your followers will sync when online"
+          onHide={() => setShow(false)}
+        />
       )}
     </>
   );

--- a/shared/ui/RefillBtn.tsx
+++ b/shared/ui/RefillBtn.tsx
@@ -4,6 +4,7 @@
  */
 import React from 'react';
 import { useBalanceStore } from './balanceStore';
+import { Toast } from './Toast';
 
 /** Button to trigger wallet refill. Attempts to mint and falls back with a toast if unreachable. */
 export const RefillBtn: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = (
@@ -18,7 +19,6 @@ export const RefillBtn: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> 
       await mint(100);
     } catch {
       setToast(true);
-      setTimeout(() => setToast(false), 3000);
     }
   };
 
@@ -32,9 +32,10 @@ export const RefillBtn: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> 
         Refill
       </button>
       {toast && (
-        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-gray-800 text-white px-4 py-2 rounded">
-          Mint unreachable. Transaction stored locally.
-        </div>
+        <Toast
+          message="Mint unreachable. Transaction stored locally."
+          onHide={() => setToast(false)}
+        />
       )}
     </>
   );

--- a/shared/ui/Toast.tsx
+++ b/shared/ui/Toast.tsx
@@ -1,0 +1,49 @@
+/*
+ * Licensed under GPL-3.0-or-later
+ * React component for Toast.
+ */
+import React from 'react';
+
+/**
+ * Toast displays a temporary notification at the bottom center of the screen.
+ * It announces itself via an ARIA status role and hides after the given duration.
+ */
+export interface ToastProps {
+  /** Message to display inside the toast. */
+  message: string;
+  /** Duration in milliseconds before auto-hiding. Defaults to 3000ms. */
+  duration?: number;
+  /** Optional callback invoked after the toast hides. */
+  onHide?: () => void;
+}
+
+export const Toast: React.FC<ToastProps> = ({
+  message,
+  duration = 3000,
+  onHide,
+}) => {
+  const [visible, setVisible] = React.useState(true);
+
+  React.useEffect(() => {
+    const id = setTimeout(() => {
+      setVisible(false);
+      onHide?.();
+    }, duration);
+    return () => clearTimeout(id);
+  }, [duration, onHide]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="assertive"
+      className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-gray-800 text-white px-4 py-2 rounded"
+    >
+      {message}
+    </div>
+  );
+};
+
+export default Toast;
+

--- a/shared/ui/TranscodeModal.tsx
+++ b/shared/ui/TranscodeModal.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { FFmpeg } from '@ffmpeg/ffmpeg';
 import { createRPCClient } from '../rpc';
+import { Toast } from './Toast';
 
 /**
  * TranscodeModal uses ffmpeg.wasm to transcode a selected file into a
@@ -26,7 +27,7 @@ export const TranscodeModal: React.FC<TranscodeModalProps> = ({
   onComplete,
 }) => {
   const [progress, setProgress] = React.useState(0);
-  const [showSnackbar, setShowSnackbar] = React.useState(false);
+  const [toast, setToast] = React.useState(false);
 
   React.useEffect(() => {
     if (!open || !file) return;
@@ -71,7 +72,7 @@ export const TranscodeModal: React.FC<TranscodeModalProps> = ({
         if (!cancelled) {
           setProgress(100);
           onComplete(magnet);
-          setShowSnackbar(true);
+          setToast(true);
         }
       } catch (err) {
         if (!cancelled) setProgress(100);
@@ -102,10 +103,11 @@ export const TranscodeModal: React.FC<TranscodeModalProps> = ({
           </Dialog.Content>
         </Dialog.Portal>
       </Dialog.Root>
-      {showSnackbar && (
-        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-gray-800 text-white px-4 py-2 rounded">
-          Transcode complete
-        </div>
+      {toast && (
+        <Toast
+          message="Transcode complete"
+          onHide={() => setToast(false)}
+        />
       )}
     </>
   );

--- a/shared/ui/index.ts
+++ b/shared/ui/index.ts
@@ -41,5 +41,6 @@ export * from './BackupSeedBtn';
 export * from './Settings';
 export * from './PostMenu';
 export * from './CommentsDrawer';
+export * from './Toast';
 export { default as FabRecord } from './FabRecord';
 export { default as VideoRecorder } from './VideoRecorder';


### PR DESCRIPTION
## Summary
- add `Toast` component with customizable message and auto-hide timer
- replace hardcoded toasts in publish/refill buttons, transcode modal and onboarding flow

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689059d81b7c8331b504a9c84dba2719