### PR TITLE
refactor: use semantic colors

### DIFF
--- a/apps/web/src/routes/Discover.tsx
+++ b/apps/web/src/routes/Discover.tsx
@@ -43,7 +43,7 @@ export default function Discover() {
           <button
             key={t.tag}
             onClick={() => onTag(t.tag)}
-            className="shrink-0 rounded-full bg-gray-200 px-3 py-1"
+            className="shrink-0 rounded-full bg-subtleBg px-3 py-1"
           >
             #{t.tag}
           </button>

--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -366,7 +366,7 @@ function OnboardingContent() {
           {avatarSrc && !avatarPreview && (
             <div className="flex flex-col items-center">
               {/* Explicit sizing ensures Cropper renders correctly */}
-              <div className="relative w-64 h-64 bg-gray-200 mb-4">
+              <div className="relative w-64 h-64 bg-subtleBg mb-4">
                 <Cropper
                   image={avatarSrc}
                   crop={crop}
@@ -378,7 +378,7 @@ function OnboardingContent() {
                 />
               </div>
               <button
-                className="rounded bg-blue-700 hover:bg-blue-800 text-white px-4 py-3 min-w-[44px] min-h-[44px]"
+                className="rounded bg-primary hover:bg-primary text-white px-4 py-3 min-w-[44px] min-h-[44px]"
                 onClick={async () => {
                   const preview = await saveAvatar();
                   if (!preview) return;
@@ -406,13 +406,13 @@ function OnboardingContent() {
           )}
           <div className="flex justify-between">
             <button
-              className="rounded bg-gray-700 hover:bg-gray-800 text-white px-4 py-3 min-w-[44px] min-h-[44px]"
+              className="rounded bg-subtleBg hover:bg-surface text-white px-4 py-3 min-w-[44px] min-h-[44px]"
               onClick={() => setStep(1)}
             >
               Back
             </button>
             <button
-              className="rounded bg-blue-700 hover:bg-blue-800 text-white px-4 py-3 min-w-[44px] min-h-[44px]"
+              className="rounded bg-primary hover:bg-primary text-white px-4 py-3 min-w-[44px] min-h-[44px]"
               onClick={async () => {
                 const err = validateUsername(username);
                 if (err) {
@@ -552,14 +552,14 @@ function OnboardingContent() {
           </Dropzone>
           <div className="flex justify-between">
           <button
-            className="rounded bg-gray-700 hover:bg-gray-800 text-white px-4 py-3 min-w-[44px] min-h-[44px]"
+            className="rounded bg-subtleBg hover:bg-surface text-white px-4 py-3 min-w-[44px] min-h-[44px]"
             onClick={() => setStep(1)}
             disabled={profileLoading || walletLoading}
           >
             Back
           </button>
           <button
-            className="rounded bg-blue-700 hover:bg-blue-800 text-white px-4 py-3 min-w-[44px] min-h-[44px]"
+            className="rounded bg-primary hover:bg-primary text-white px-4 py-3 min-w-[44px] min-h-[44px]"
             onClick={() => {
               if (mode !== 'import' || (!profileBackup && !walletBackup)) return;
               const profileData: any = { ...profileBackup };
@@ -599,13 +599,13 @@ function OnboardingContent() {
           </div>
           <div className="flex justify-between">
             <button
-              className="rounded bg-gray-700 hover:bg-gray-800 text-white px-4 py-3 min-w-[44px] min-h-[44px]"
+              className="rounded bg-subtleBg hover:bg-surface text-white px-4 py-3 min-w-[44px] min-h-[44px]"
               onClick={() => setStep(2)}
             >
               Back
             </button>
             <button
-              className="rounded bg-blue-700 hover:bg-blue-800 text-white px-4 py-3 min-w-[44px] min-h-[44px]"
+              className="rounded bg-primary hover:bg-primary text-white px-4 py-3 min-w-[44px] min-h-[44px]"
               onClick={confirm}
             >
               Confirm

--- a/apps/web/src/routes/SettingsOverlay.tsx
+++ b/apps/web/src/routes/SettingsOverlay.tsx
@@ -14,7 +14,7 @@ export default function SettingsOverlay() {
   return (
     <Dialog.Root open onOpenChange={(o) => { if (!o) window.history.back(); }}>
       <Dialog.Overlay className="fixed inset-0 bg-black/50" />
-      <Dialog.Content className="fixed inset-0 flex flex-col bg-white dark:bg-gray-900">
+      <Dialog.Content className="fixed inset-0 flex flex-col bg-white dark:bg-surface">
         <header className="flex items-center justify-between border-b p-4">
           <h1 className="text-xl font-semibold">Settings</h1>
           <Dialog.Close aria-label="Close" className="text-xl">×</Dialog.Close>

--- a/shared/ui/Avatar.tsx
+++ b/shared/ui/Avatar.tsx
@@ -22,7 +22,7 @@ export const Avatar: React.FC<AvatarProps> = ({
 }) => {
   const dimension = typeof size === 'number' ? `${size}px` : size;
   const baseClass =
-    'flex items-center justify-center rounded-full bg-gray-200 overflow-hidden text-gray-600';
+    'flex items-center justify-center rounded-full bg-subtleBg overflow-hidden text-gray-600';
   return (
     <div
       className={`${baseClass} ${className ?? ''}`}

--- a/shared/ui/BottomNav.tsx
+++ b/shared/ui/BottomNav.tsx
@@ -36,7 +36,7 @@ export const BottomNav: React.FC = () => {
   return (
     <>
       <nav
-        className={`fixed bottom-0 left-0 right-0 flex justify-around bg-gray-100 dark:bg-gray-800 p-2 transition-transform duration-300 motion-reduce:transition-none sm:hidden ${hidden ? 'translate-y-full' : ''}`}
+        className={`fixed bottom-0 left-0 right-0 flex justify-around bg-subtleBg dark:bg-surface p-2 transition-transform duration-300 motion-reduce:transition-none sm:hidden ${hidden ? 'translate-y-full' : ''}`}
       >
         <motion.a
           href="/"

--- a/shared/ui/FollowBtn.tsx
+++ b/shared/ui/FollowBtn.tsx
@@ -18,7 +18,7 @@ export const FollowBtn: React.FC<FollowBtnProps> = ({ creatorId }) => {
 
   return (
     <button
-      className="px-3 py-1 rounded bg-blue-600 text-white text-sm"
+      className="px-3 py-1 rounded bg-primary text-white text-sm"
       onClick={() => toggleFollow(creatorId)}
     >
       {isFollowing ? 'Unfollow' : 'Follow'}

--- a/shared/ui/InstallBanner.tsx
+++ b/shared/ui/InstallBanner.tsx
@@ -41,7 +41,7 @@ export const InstallBanner: React.FC<InstallBannerProps> = ({ onFinish }) => {
       <p className="mb-4">Add this app to your home screen.</p>
       <button
         onClick={install}
-        className="rounded bg-blue-500 px-4 py-2 text-white"
+        className="rounded bg-primary px-4 py-2 text-white"
         autoFocus
       >
         {deferred ? 'Install' : 'Continue'}

--- a/shared/ui/MintSelect.tsx
+++ b/shared/ui/MintSelect.tsx
@@ -33,7 +33,7 @@ export const MintSelect: React.FC<MintSelectProps> = ({ onNext }) => {
       />
       <button
         onClick={handleNext}
-        className="mt-4 rounded bg-blue-500 px-4 py-2 text-white"
+        className="mt-4 rounded bg-primary px-4 py-2 text-white"
       >
         Next
       </button>

--- a/shared/ui/Nav.tsx
+++ b/shared/ui/Nav.tsx
@@ -12,7 +12,7 @@ export const Nav: React.FC = () => {
   const [open, setOpen] = React.useState(false);
 
   return (
-    <header className="sticky top-0 z-10 flex items-center justify-between bg-gray-100 dark:bg-gray-800 p-2 shadow text-gray-900 dark:text-gray-100">
+    <header className="sticky top-0 z-10 flex items-center justify-between bg-subtleBg dark:bg-surface p-2 shadow text-gray-900 dark:text-gray-100">
       <div className="flex items-center gap-2 font-bold">
         <img src="/logo.svg" alt="CashuCast logo" className="h-6 w-6" />
         CashuCast
@@ -22,7 +22,7 @@ export const Nav: React.FC = () => {
         <ToggleDarkMode />
         <button
           onClick={() => setOpen(true)}
-          className="rounded bg-gray-200 dark:bg-gray-700 px-2 py-1 text-gray-900 dark:text-gray-100"
+          className="rounded bg-subtleBg dark:bg-surface px-2 py-1 text-gray-900 dark:text-gray-100"
         >
           Wallet
         </button>

--- a/shared/ui/PostMenu.tsx
+++ b/shared/ui/PostMenu.tsx
@@ -51,13 +51,13 @@ export const PostMenu: React.FC<PostMenuProps> = ({
         <div className="absolute right-0 z-10 mt-2 w-40 rounded-md bg-white shadow-lg ring-1 ring-black/5">
           <div className="py-1">
             <button
-              className="block w-full px-4 py-2 text-left text-sm hover:bg-gray-100"
+              className="block w-full px-4 py-2 text-left text-sm hover:bg-subtleBg"
               onClick={() => setReportOpen(true)}
             >
               Report
             </button>
             <button
-              className="block w-full px-4 py-2 text-left text-sm hover:bg-gray-100"
+              className="block w-full px-4 py-2 text-left text-sm hover:bg-subtleBg"
               onClick={handleBlock}
             >
               Block author
@@ -70,7 +70,7 @@ export const PostMenu: React.FC<PostMenuProps> = ({
           {reasons.map((r) => (
             <button
               key={r}
-              className="block w-full rounded p-2 text-left hover:bg-gray-100"
+              className="block w-full rounded p-2 text-left hover:bg-subtleBg"
               onClick={() => handleReport(r)}
             >
               {r}

--- a/shared/ui/Profile.tsx
+++ b/shared/ui/Profile.tsx
@@ -34,7 +34,7 @@ export const Profile: React.FC<ProfileProps> = ({
   return (
     <div className="flex flex-col gap-4 p-4">
       {blocked && (
-        <div className="rounded bg-gray-200 p-2 text-center text-sm text-gray-700">
+        <div className="rounded bg-subtleBg p-2 text-center text-sm text-gray-700">
           You have blocked this user.
         </div>
       )}

--- a/shared/ui/PublishBtn.tsx
+++ b/shared/ui/PublishBtn.tsx
@@ -26,7 +26,7 @@ export const PublishBtn: React.FC<PublishBtnProps> = ({ magnet, onPublish }) => 
       <button
         disabled={!magnet}
         onClick={handleClick}
-        className="px-4 py-2 bg-blue-500 text-white rounded disabled:bg-gray-400"
+        className="px-4 py-2 bg-primary text-white rounded disabled:bg-surface"
       >
         Publish
       </button>

--- a/shared/ui/QuotaBar.tsx
+++ b/shared/ui/QuotaBar.tsx
@@ -24,7 +24,7 @@ export const QuotaBar: React.FC = () => {
 
   return (
     <div className="space-y-1">
-      <div className="h-2 w-full bg-gray-200 rounded">
+      <div className="h-2 w-full bg-subtleBg rounded">
         <div
           className="h-2 bg-green-500 rounded"
           style={{ width: `${pct}%` }}

--- a/shared/ui/RefillBtn.tsx
+++ b/shared/ui/RefillBtn.tsx
@@ -27,7 +27,7 @@ export const RefillBtn: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> 
       <button
         {...props}
         onClick={handleClick}
-        className={`px-3 py-1 bg-blue-500 text-white rounded ${props.className ?? ''}`}
+        className={`px-3 py-1 bg-primary text-white rounded ${props.className ?? ''}`}
       >
         Refill
       </button>

--- a/shared/ui/SkeletonLoader.test.tsx
+++ b/shared/ui/SkeletonLoader.test.tsx
@@ -13,7 +13,7 @@ describe('SkeletonLoader', () => {
     vi.resetModules();
     const { SkeletonLoader } = await import('./SkeletonLoader');
     const html = renderToStaticMarkup(<SkeletonLoader />);
-    expect(html).toContain('bg-gray-200');
+    expect(html).toContain('bg-subtleBg');
     expect(html).toContain('bg-gradient-to-r');
     expect(html).toContain('animate-skeleton-shimmer');
   });

--- a/shared/ui/SkeletonLoader.tsx
+++ b/shared/ui/SkeletonLoader.tsx
@@ -14,7 +14,7 @@ export interface SkeletonLoaderProps {
  */
 export const SkeletonLoader: React.FC<SkeletonLoaderProps> = ({ className }) => {
   return (
-    <div className={`relative overflow-hidden bg-gray-200 ${className ?? ''}`}>
+    <div className={`relative overflow-hidden bg-subtleBg ${className ?? ''}`}>
       <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200 animate-skeleton-shimmer" />
     </div>
   );

--- a/shared/ui/Stepper.tsx
+++ b/shared/ui/Stepper.tsx
@@ -79,7 +79,7 @@ export const Stepper: React.FC = () => {
                   }
                   setStep(1);
                 }}
-                className="rounded bg-blue-700 hover:bg-blue-800 px-4 py-3 text-white min-w-[44px] min-h-[44px] disabled:cursor-not-allowed disabled:opacity-50"
+                className="rounded bg-primary hover:bg-primary px-4 py-3 text-white min-w-[44px] min-h-[44px] disabled:cursor-not-allowed disabled:opacity-50"
               >
                 Next
               </button>

--- a/shared/ui/Timeline.tsx
+++ b/shared/ui/Timeline.tsx
@@ -93,8 +93,8 @@ export const Timeline: React.FC = () => {
             </SwipeContainer>
           )}
         </div>
-        <div className="pointer-events-none fixed inset-y-0 left-0 hidden w-1/4 bg-gray-100/40 backdrop-blur lg:block" />
-        <div className="pointer-events-none fixed inset-y-0 right-0 hidden w-1/4 bg-gray-100/40 backdrop-blur lg:block" />
+        <div className="pointer-events-none fixed inset-y-0 left-0 hidden w-1/4 bg-subtleBg/40 backdrop-blur lg:block" />
+        <div className="pointer-events-none fixed inset-y-0 right-0 hidden w-1/4 bg-subtleBg/40 backdrop-blur lg:block" />
       </div>
       <BottomNav />
     </div>

--- a/shared/ui/TimelineCard.tsx
+++ b/shared/ui/TimelineCard.tsx
@@ -100,7 +100,7 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({
               <Avatar name={name} url={avatarUrl} size={32} />
               <span className="font-semibold">{name}</span>
               {isModerator && reports > 0 && (
-                <span className="rounded-full bg-gray-200/80 px-2 py-1 text-xs text-black">
+                <span className="rounded-full bg-subtleBg/80 px-2 py-1 text-xs text-black">
                   ⚑ {reports}
                 </span>
               )}

--- a/shared/ui/Toast.tsx
+++ b/shared/ui/Toast.tsx
@@ -38,7 +38,7 @@ export const Toast: React.FC<ToastProps> = ({
     <div
       role="status"
       aria-live="assertive"
-      className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-gray-800 text-white px-4 py-2 rounded"
+      className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-surface text-white px-4 py-2 rounded"
     >
       {message}
     </div>

--- a/shared/ui/ToggleDarkMode.tsx
+++ b/shared/ui/ToggleDarkMode.tsx
@@ -32,7 +32,7 @@ export const ToggleDarkMode: React.FC<React.ButtonHTMLAttributes<HTMLButtonEleme
         props.onClick?.(e);
         setDark((d) => !d);
       }}
-      className={`px-2 py-1 rounded bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-gray-100 ${
+      className={`px-2 py-1 rounded bg-subtleBg text-gray-900 dark:bg-surface dark:text-gray-100 ${
         props.className ?? ''
       }`}
     >

--- a/shared/ui/TranscodeModal.tsx
+++ b/shared/ui/TranscodeModal.tsx
@@ -96,8 +96,8 @@ export const TranscodeModal: React.FC<TranscodeModalProps> = ({
           <Dialog.Overlay className="fixed inset-0 bg-black/50" />
           <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white p-4 rounded shadow">
             <Dialog.Title>Transcoding</Dialog.Title>
-            <div className="w-64 bg-gray-200 h-2 mt-2">
-              <div className="bg-blue-500 h-2" style={{ width: `${progress}%` }} />
+            <div className="w-64 bg-subtleBg h-2 mt-2">
+              <div className="bg-primary h-2" style={{ width: `${progress}%` }} />
             </div>
             <p className="mt-2 text-center">{progress}%</p>
           </Dialog.Content>

--- a/shared/ui/VideoPlayer.test.tsx
+++ b/shared/ui/VideoPlayer.test.tsx
@@ -25,7 +25,7 @@ describe('VideoPlayer', () => {
     const html = renderToStaticMarkup(
       <VideoPlayer magnet="magnet:?xt=urn:btih:test" />
     );
-    expect(html).toContain('bg-gray-200');
+    expect(html).toContain('bg-subtleBg');
   });
 
   it('renders a video element once the blob URL resolves', async () => {

--- a/shared/ui/VideoPlayer.tsx
+++ b/shared/ui/VideoPlayer.tsx
@@ -51,7 +51,7 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({ magnet, postId }) => {
 
   if (src === '') {
     return (
-      <div className="flex h-full w-full items-center justify-center bg-gray-200 text-sm">
+      <div className="flex h-full w-full items-center justify-center bg-subtleBg text-sm">
         Failed to load video
       </div>
     );

--- a/shared/ui/WalletModal.tsx
+++ b/shared/ui/WalletModal.tsx
@@ -26,7 +26,7 @@ export const WalletModal: React.FC<WalletModalProps> = ({ open, onOpenChange }) 
           <button
             onClick={() => onOpenChange(false)}
             aria-label="Close wallet"
-            className="rounded bg-gray-200 px-2 py-1"
+            className="rounded bg-subtleBg px-2 py-1"
           >
             Close
           </button>


### PR DESCRIPTION
## Summary
- replace hard-coded gray/blue backgrounds with semantic tokens
- update tests to match new background classes

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68905b3d77408331be017415b10ffb66