### PR TITLE
Use dynamic viewport height for timeline card

### DIFF
--- a/shared/ui/TimelineCard.test.tsx
+++ b/shared/ui/TimelineCard.test.tsx
@@ -61,5 +61,12 @@ describe('TimelineCard', () => {
     expect(html).toContain('aria-label="Open post menu"');
     expect(html).toContain('bg-black/60');
   });
+
+  it('uses dynamic viewport height for full visibility on mobile', () => {
+    const html = renderToStaticMarkup(
+      <TimelineCard name="a" avatarUrl="" magnet={magnet} />,
+    );
+    expect(html).toContain('min-h-[100dvh]');
+  });
 });
 

--- a/shared/ui/TimelineCard.tsx
+++ b/shared/ui/TimelineCard.tsx
@@ -70,7 +70,7 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({
   return (
     <>
       <motion.article
-        className="relative h-[90vh] w-full rounded-card shadow-sm overflow-hidden"
+        className="relative min-h-[100dvh] w-full rounded-card shadow-sm overflow-hidden"
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4 }}


### PR DESCRIPTION
## Summary
- replace fixed `h-[90vh]` height with `min-h-[100dvh]` to keep timeline card fully visible as mobile browsers collapse their address bars
- add regression test confirming dynamic viewport unit usage

## Testing
- `pnpm lint shared/ui/TimelineCard.tsx shared/ui/TimelineCard.test.tsx`
- `pnpm test shared/ui/TimelineCard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68905d0ceb8c83318d63e816ac9616a4