### PR TITLE
feat: initialize dark mode based on preference

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,6 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script>
+    const theme = localStorage.getItem('theme');
+    if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  </script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet" />
   <title>CashuCast</title>
 </head>

--- a/shared/ui/ToggleDarkMode.tsx
+++ b/shared/ui/ToggleDarkMode.tsx
@@ -9,8 +9,8 @@ export const ToggleDarkMode: React.FC<React.ButtonHTMLAttributes<HTMLButtonEleme
   props,
 ) => {
   const [dark, setDark] = React.useState(() => {
-    if (typeof window === 'undefined') return false;
-    return localStorage.getItem('theme') === 'dark';
+    if (typeof document === 'undefined') return false;
+    return document.documentElement.classList.contains('dark');
   });
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary
- set initial dark mode based on localStorage or OS preference
- default ToggleDarkMode to the initial document theme

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6890603b90c883319f667b6ac46ba8c4