### PR TITLE
feat: add min tap utility

### DIFF
--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -378,7 +378,7 @@ function OnboardingContent() {
                 />
               </div>
               <button
-                className="rounded bg-primary hover:bg-primary text-white px-4 py-3 min-w-[44px] min-h-[44px]"
+                className="rounded bg-primary hover:bg-primary text-white px-4 py-3 min-tap"
                 onClick={async () => {
                   const preview = await saveAvatar();
                   if (!preview) return;
@@ -406,13 +406,13 @@ function OnboardingContent() {
           )}
           <div className="flex justify-between">
             <button
-              className="rounded bg-subtleBg hover:bg-surface text-white px-4 py-3 min-w-[44px] min-h-[44px]"
+              className="rounded bg-subtleBg hover:bg-surface text-white px-4 py-3 min-tap"
               onClick={() => setStep(1)}
             >
               Back
             </button>
             <button
-              className="rounded bg-primary hover:bg-primary text-white px-4 py-3 min-w-[44px] min-h-[44px]"
+              className="rounded bg-primary hover:bg-primary text-white px-4 py-3 min-tap"
               onClick={async () => {
                 const err = validateUsername(username);
                 if (err) {
@@ -462,7 +462,7 @@ function OnboardingContent() {
                     }
                   },
                 })}
-                className="border-2 border-dashed cursor-pointer text-center px-4 py-3 min-w-[44px] min-h-[44px]"
+                className="border-2 border-dashed cursor-pointer text-center px-4 py-3 min-tap"
                 aria-describedby="profile-upload-caption"
               >
                 <label htmlFor="profile-upload" className="sr-only">
@@ -521,7 +521,7 @@ function OnboardingContent() {
                     }
                   },
                 })}
-                className="border-2 border-dashed cursor-pointer text-center px-4 py-3 min-w-[44px] min-h-[44px]"
+                className="border-2 border-dashed cursor-pointer text-center px-4 py-3 min-tap"
                 aria-describedby="wallet-upload-caption"
               >
                 <label htmlFor="wallet-upload" className="sr-only">
@@ -552,14 +552,14 @@ function OnboardingContent() {
           </Dropzone>
           <div className="flex justify-between">
           <button
-            className="rounded bg-subtleBg hover:bg-surface text-white px-4 py-3 min-w-[44px] min-h-[44px]"
+            className="rounded bg-subtleBg hover:bg-surface text-white px-4 py-3 min-tap"
             onClick={() => setStep(1)}
             disabled={profileLoading || walletLoading}
           >
             Back
           </button>
           <button
-            className="rounded bg-primary hover:bg-primary text-white px-4 py-3 min-w-[44px] min-h-[44px]"
+            className="rounded bg-primary hover:bg-primary text-white px-4 py-3 min-tap"
             onClick={() => {
               if (mode !== 'import' || (!profileBackup && !walletBackup)) return;
               const profileData: any = { ...profileBackup };
@@ -599,13 +599,13 @@ function OnboardingContent() {
           </div>
           <div className="flex justify-between">
             <button
-              className="rounded bg-subtleBg hover:bg-surface text-white px-4 py-3 min-w-[44px] min-h-[44px]"
+              className="rounded bg-subtleBg hover:bg-surface text-white px-4 py-3 min-tap"
               onClick={() => setStep(2)}
             >
               Back
             </button>
             <button
-              className="rounded bg-primary hover:bg-primary text-white px-4 py-3 min-w-[44px] min-h-[44px]"
+              className="rounded bg-primary hover:bg-primary text-white px-4 py-3 min-tap"
               onClick={confirm}
             >
               Confirm

--- a/shared/ui/Stepper.tsx
+++ b/shared/ui/Stepper.tsx
@@ -79,7 +79,7 @@ export const Stepper: React.FC = () => {
                   }
                   setStep(1);
                 }}
-                className="rounded bg-primary hover:bg-primary px-4 py-3 text-white min-w-[44px] min-h-[44px] disabled:cursor-not-allowed disabled:opacity-50"
+                className="rounded bg-primary hover:bg-primary px-4 py-3 text-white min-tap disabled:cursor-not-allowed disabled:opacity-50"
               >
                 Next
               </button>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -40,6 +40,10 @@ module.exports = {
           filter:
             'drop-shadow(0 10px 8px rgba(0 0 0 / 0.04)) drop-shadow(0 4px 3px rgba(0 0 0 / 0.1))',
         },
+        '.min-tap': {
+          minWidth: '44px',
+          minHeight: '44px',
+        },
       });
     }),
   ],


### PR DESCRIPTION
## Summary
- add `.min-tap` utility for 44px min width/height tap targets
- replace explicit `min-w-[44px] min-h-[44px]` usages with new utility

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689061356f3883319dfa4d5d9e8a303c