### PR TITLE
chore(web): remove unused Onboarding import from router

### DIFF
--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -3,7 +3,6 @@
  * React component for router.
  */
 import React from 'react';
-import Onboarding from './routes/Onboarding';
 import Compose from './routes/Compose';
 import SettingsOverlay from './routes/SettingsOverlay';
 import SearchResults from './routes/SearchResults';


### PR DESCRIPTION
## Summary
- remove unused Onboarding import from the web router

## Testing
- `pnpm exec eslint apps/web/src/router.tsx`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68906928c8e48331979b481454a7c84b