### PR TITLE
Handle missing profile export

### DIFF
--- a/shared/store/profile.test.ts
+++ b/shared/store/profile.test.ts
@@ -47,3 +47,15 @@ describe('importProfile', () => {
     expect(useProfile.getState().profile).toEqual(profile);
   });
 });
+
+describe('exportProfile', () => {
+  beforeEach(() => {
+    mockStorage();
+    useProfile.setState({ profile: undefined });
+  });
+
+  it('returns empty json when no profile is present', async () => {
+    const blob = useProfile.getState().exportProfile();
+    expect(await blob.text()).toBe('{}');
+  });
+});

--- a/shared/store/profile.ts
+++ b/shared/store/profile.ts
@@ -34,7 +34,11 @@ export const useProfile = create<ProfileState>()(
         set({ profile: json });
       },
       exportProfile() {
-        return new Blob([JSON.stringify(get().profile)], {
+        const profile = get().profile;
+        if (!profile) {
+          return new Blob(['{}'], { type: 'application/json' });
+        }
+        return new Blob([JSON.stringify(profile)], {
           type: 'application/json',
         });
       },


### PR DESCRIPTION
## Summary
- ensure `exportProfile` returns an empty JSON blob when no profile is present
- test `exportProfile` without a profile

## Testing
- `pnpm lint packages/shared/store/profile.ts packages/shared/store/profile.test.ts`
- `pnpm test packages/shared/store/profile.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68906a2250908331b2b20ca955cd2809