### PR TITLE
Wait for profile hydration before rendering

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,8 +10,20 @@ import SearchBar from './components/SearchBar';
 
 export default function App() {
   const { profile } = useProfile();
-  const hasProfile = Boolean(profile?.ssbPk);
+  const [hydrated, setHydrated] = React.useState(() =>
+    useProfile.persist.hasHydrated(),
+  );
 
+  React.useEffect(() => {
+    const unsub = useProfile.persist.onFinish(() => setHydrated(true));
+    return unsub;
+  }, []);
+
+  if (!hydrated) {
+    return null;
+  }
+
+  const hasProfile = Boolean(profile?.ssbPk);
   if (!hasProfile) {
     return <Onboarding />;
   }


### PR DESCRIPTION
## Summary
- prevent premature onboarding by waiting for profile store hydration

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68906b0ea1ac83318339ff6e598c8efd