### PR TITLE
feat(web): use client-side navigation after onboarding

### DIFF
--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -187,9 +187,8 @@ function OnboardingContent() {
       setProfile(profile);
     }
     setToast(true);
-    setTimeout(() => {
-      window.location.href = '/';
-    }, 1000);
+    window.history.pushState(null, '', '/');
+    window.dispatchEvent(new PopStateEvent('popstate'));
   };
 
   return (


### PR DESCRIPTION
## Summary
- use client-side navigation after completing onboarding

## Testing
- `pnpm lint apps/web/src/routes/Onboarding.tsx`
- `pnpm test apps/web/src/routes/Onboarding.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68906c3d56608331bd509a60d1ac4dfc