### PR TITLE
fix: update persist hydration callback

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -15,7 +15,9 @@ export default function App() {
   );
 
   React.useEffect(() => {
-    const unsub = useProfile.persist.onFinish(() => setHydrated(true));
+    const unsub = useProfile.persist.onFinishHydration(() =>
+      setHydrated(true),
+    );
     return unsub;
   }, []);
 


### PR DESCRIPTION
## Summary
- replace deprecated `persist.onFinish` with `persist.onFinishHydration`

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68906d062558833193f7c9fe5ab6cf81