### PR TITLE
feat(web): overlay onboarding over app

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -26,9 +26,6 @@ export default function App() {
   }
 
   const hasProfile = Boolean(profile?.ssbPk);
-  if (!hasProfile) {
-    return <Onboarding />;
-  }
 
   const [path, setPath] = React.useState(() => window.location.pathname);
 
@@ -38,12 +35,19 @@ export default function App() {
     return () => window.removeEventListener('popstate', onPopState);
   }, []);
 
+  React.useEffect(() => {
+    setPath(window.location.pathname);
+  }, [hasProfile]);
+
   const RouteComponent = ROUTES[path];
 
   return (
     <>
-      {RouteComponent ? <RouteComponent /> : <div>Not Found</div>}
-      <SearchBar />
+      {!hasProfile && <Onboarding />}
+      <div id="app-container" hidden={!hasProfile}>
+        {RouteComponent ? <RouteComponent /> : <div>Not Found</div>}
+        <SearchBar />
+      </div>
     </>
   );
 }

--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -623,11 +623,24 @@ function OnboardingContent() {
   );
 }
 
+function AriaHidingOverlay() {
+  useEffect(() => {
+    const app = document.getElementById('app-container');
+    if (app) app.setAttribute('aria-hidden', 'true');
+    return () => {
+      if (app) app.removeAttribute('aria-hidden');
+    };
+  }, []);
+  return (
+    <Dialog.Overlay className="fixed inset-0 bg-black/50 dark:bg-white/20 z-40" />
+  );
+}
+
 export default function Onboarding() {
   return (
     <Dialog.Root open>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/50 dark:bg-white/20 z-40" />
+        <AriaHidingOverlay />
         <Dialog.Content className="fixed inset-0 flex items-center justify-center z-50">
           <Dialog.Title className="sr-only">Onboarding</Dialog.Title>
           <Dialog.Description className="sr-only">


### PR DESCRIPTION
## Summary
- display onboarding before main app markup and hide app container until profile exists
- add overlay that hides the DOM from assistive tech during onboarding

## Testing
- `pnpm lint apps/web/src/App.tsx apps/web/src/routes/Onboarding.tsx`
- `pnpm test apps/web/src/routes/Onboarding.test.tsx`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6890734475188331b8107da9a705b3a0