### PR TITLE
Remove back buttons in onboarding flow

### DIFF
--- a/apps/web/src/routes/Onboarding.test.tsx
+++ b/apps/web/src/routes/Onboarding.test.tsx
@@ -378,7 +378,7 @@ describe('Onboarding steps', () => {
     expect(container.textContent).toContain('Invalid profile backup');
   });
 
-  it('shows step indicator and Back navigation', async () => {
+  it('shows step indicator and allows canceling to restart', async () => {
     const { container, root } = setupDom();
     await act(async () => {
       root.render(<Onboarding />);
@@ -390,20 +390,13 @@ describe('Onboarding steps', () => {
       newBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(container.textContent).toContain('Step 2 of 3');
-    const backBtn = Array.from(container.querySelectorAll('button')).find(
-      (b) => b.textContent === 'Back',
+    const cancelBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Cancel',
     )!;
     await act(async () => {
-      backBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      cancelBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(container.textContent).toContain('Step 1 of 3');
-    const newBtn2 = Array.from(container.querySelectorAll('button')).find((b) =>
-      b.textContent?.includes('New Account'),
-    )!;
-    await act(async () => {
-      newBtn2.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    expect(container.textContent).toContain('Step 2 of 3');
   });
 
   it.skip('allows user to reach final confirmation step via import flow', async () => {

--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -196,33 +196,25 @@ function OnboardingContent() {
       ref={containerRef}
       className="relative space-y-4 sm:space-y-6 md:space-y-8"
     >
-      {step > 1 && (
-        <button
-          className="absolute top-4 left-4 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-white"
-          onClick={() => setStep(step - 1)}
-        >
-          ← Back
-        </button>
-      )}
+      <button
+        type="button"
+        className="absolute top-4 right-4 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-white"
+        onClick={() => {
+          if (step === 1) {
+            window.history.pushState(null, '', '/');
+            window.dispatchEvent(new PopStateEvent('popstate'));
+          }
+          setStep(1);
+          setMode(null);
+        }}
+      >
+        Cancel
+      </button>
       <div aria-live="polite" className="sr-only">
         {stepTitle}
       </div>
-      <div className="flex justify-between items-center text-sm text-gray-500">
-        <span className="text-gray-500 dark:text-gray-400">
-          Step {step} of 3
-        </span>
-        {step > 1 && (
-          <button
-            type="button"
-            onClick={() => {
-              setStep(1);
-              setMode(null);
-            }}
-            className="hover:underline"
-          >
-            Cancel
-          </button>
-        )}
+      <div className="text-sm text-gray-500 dark:text-gray-400">
+        Step {step} of 3
       </div>
       {step === 1 && (
         <div className="flex flex-col gap-4">
@@ -403,13 +395,7 @@ function OnboardingContent() {
               />
             </div>
           )}
-          <div className="flex justify-between">
-            <button
-              className="rounded bg-subtleBg hover:bg-surface px-4 py-3 min-tap"
-              onClick={() => setStep(1)}
-            >
-              Back
-            </button>
+          <div className="flex justify-end">
             <button
               className="rounded bg-primary hover:bg-primary px-4 py-3 min-tap"
               onClick={async () => {
@@ -549,14 +535,7 @@ function OnboardingContent() {
               </div>
             )}
           </Dropzone>
-          <div className="flex justify-between">
-          <button
-            className="rounded bg-subtleBg hover:bg-surface px-4 py-3 min-tap"
-            onClick={() => setStep(1)}
-            disabled={profileLoading || walletLoading}
-          >
-            Back
-          </button>
+            <div className="flex justify-end">
           <button
             className="rounded bg-primary hover:bg-primary px-4 py-3 min-tap"
             onClick={() => {
@@ -596,13 +575,7 @@ function OnboardingContent() {
             )}
             <span>{mode === 'new' ? username : profile?.username}</span>
           </div>
-          <div className="flex justify-between">
-            <button
-            className="rounded bg-subtleBg hover:bg-surface px-4 py-3 min-tap"
-            onClick={() => setStep(2)}
-          >
-            Back
-          </button>
+            <div className="flex justify-end">
           <button
             className="rounded bg-primary hover:bg-primary px-4 py-3 min-tap"
             onClick={confirm}


### PR DESCRIPTION
## Summary
- drop top-left back button and step-level back buttons
- keep single top-right Cancel to reset or exit onboarding
- adjust tests for new navigation

## Testing
- `pnpm lint`
- `pnpm test apps/web/src/routes/Onboarding.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68907526e39883319b37944bf5327acf