### PR TITLE
Fix cropper CSS import

### DIFF
--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -15,7 +15,7 @@ import { z } from 'zod';
 import { UserPlus, Upload, DownloadCloud } from 'lucide-react';
 import { Avatar } from '../../shared/ui/Avatar';
 import { Toast } from '../../shared/ui/Toast';
-import 'react-easy-crop/react-easy-crop.css';
+import 'react-easy-crop/dist/react-easy-crop.css';
 
 // schemas for validating imported backups
 const ProfileBackupSchema = z.object({

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -43,6 +43,8 @@ export default defineConfig({
       dns: path.resolve(__dirname, 'empty-module.js'),
       'bittorrent-dht': path.resolve(__dirname, 'dht-shim.js'),
       'torrent-discovery': path.resolve(__dirname, 'empty-module.js'),
+      // react-easy-crop's CSS was moved under dist in v5
+      'react-easy-crop/dist': 'react-easy-crop',
     },
   },
   optimizeDeps: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,4 +8,9 @@ export default defineConfig({
   test: {
     environment: 'node',
   },
+  resolve: {
+    alias: {
+      'react-easy-crop/dist': 'react-easy-crop',
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- fix react-easy-crop style import path
- alias new react-easy-crop CSS path in build and test configs

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm --filter web dev`


------
https://chatgpt.com/codex/tasks/task_e_689079f9dd0c8331a1f663c2612ca2f2