### PR TITLE
fix(web): polyfill process for browser libs

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -7,6 +7,16 @@ import "../index.css";
 import { createRoot } from "react-dom/client";
 
 async function bootstrap() {
+  // Polyfill Node's `process` globally when running in the browser.
+  if (!(globalThis as any).process) {
+    (globalThis as any).process = {
+      env: {},
+      browser: true,
+      nextTick: (cb: (...args: any[]) => void) => setTimeout(cb, 0),
+      exit: () => {},
+    };
+  }
+
   // Polyfill Node's `Buffer` globally when running in the browser. Vite
   // externalizes built-in modules, so we dynamically load the `buffer`
   // package's implementation instead.


### PR DESCRIPTION
## Summary
- polyfill Node's `process` global in the web bootstrap

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68907c7b3e18833191583ac6bdde8dbc