### PR TITLE
feat: improve button accessibility

### DIFF
--- a/apps/web/src/components/ActionColumn.tsx
+++ b/apps/web/src/components/ActionColumn.tsx
@@ -33,7 +33,7 @@ export default function ActionColumn({ post, rpc, onOpenComments }: ActionColumn
       <button
         aria-label="Boost"
         onClick={() => rpc?.('publish', { type: 'repost', link: id })}
-        className="flex flex-col items-center transition hover:scale-110"
+        className="flex flex-col items-center transition hover:scale-110 min-tap"
       >
         <Repeat size={28} />
         <span className="text-xs">{boosters?.length || 0}</span>
@@ -44,7 +44,7 @@ export default function ActionColumn({ post, rpc, onOpenComments }: ActionColumn
         onClick={() => {
           if (authorPubKey) rpc?.('sendZap', authorPubKey, 1, id);
         }}
-        className="flex flex-col items-center transition hover:scale-110"
+        className="flex flex-col items-center transition hover:scale-110 min-tap"
       >
         <Zap size={28} />
         <span className="text-xs">{zaps || 0}</span>
@@ -53,7 +53,7 @@ export default function ActionColumn({ post, rpc, onOpenComments }: ActionColumn
       <button
         aria-label="Comment"
         onClick={() => onOpenComments(post)}
-        className="flex flex-col items-center transition hover:scale-110"
+        className="flex flex-col items-center transition hover:scale-110 min-tap"
       >
         <MessageCircle size={28} />
         <span className="text-xs">{comments || 0}</span>

--- a/apps/web/src/components/CommentsDrawer.tsx
+++ b/apps/web/src/components/CommentsDrawer.tsx
@@ -78,7 +78,7 @@ export const CommentsDrawer: React.FC<CommentsDrawerProps> = ({
             />
             <button
               type="submit"
-              className="rounded bg-purple-600 px-4 py-1"
+              className="rounded bg-purple-600 px-4 py-1 min-tap"
             >
               Send
             </button>

--- a/apps/web/src/components/FilterBar.tsx
+++ b/apps/web/src/components/FilterBar.tsx
@@ -27,7 +27,8 @@ export default function FilterBar() {
         >
           #{t}
           <button
-            className="ml-1 text-gray-600 hover:text-gray-900"
+            aria-label={`Remove ${t}`}
+            className="ml-1 text-gray-600 hover:text-gray-900 flex items-center justify-center min-tap"
             onClick={() => toggleTag(t)}
           >
             ×

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -120,7 +120,7 @@ export default function SearchBar() {
         <button
           aria-label="Search"
           onClick={() => setOpen(true)}
-          className="p-2"
+          className="p-2 min-tap flex items-center justify-center"
         >
           <Search className="h-5 w-5" />
         </button>

--- a/apps/web/src/components/ThumbnailPicker.tsx
+++ b/apps/web/src/components/ThumbnailPicker.tsx
@@ -127,7 +127,7 @@ export default function ThumbnailPicker({ file, onSelect }: ThumbnailPickerProps
             />
           </div>
           <button
-            className="mt-2 rounded bg-blue-500 px-4 py-2"
+            className="mt-2 rounded bg-blue-500 px-4 py-2 min-tap"
             onClick={createCroppedImage}
           >
             Use

--- a/apps/web/src/components/TimelineCard.tsx
+++ b/apps/web/src/components/TimelineCard.tsx
@@ -101,7 +101,7 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({ post }) => {
           <div className="p-4 pointer-events-auto">
             <button
               type="button"
-              className="flex items-center gap-2"
+              className="flex items-center gap-2 min-tap"
               onClick={(e) => {
                 e.stopPropagation();
                 if (authorPubKey) setProfileOpen(true);

--- a/shared/ui/BackupSeedBtn.tsx
+++ b/shared/ui/BackupSeedBtn.tsx
@@ -25,7 +25,7 @@ export const BackupSeedBtn: React.FC<React.ButtonHTMLAttributes<HTMLButtonElemen
     <button
       {...props}
       onClick={handleClick}
-      className={`px-3 py-1 bg-green-600 rounded ${props.className ?? ''}`}
+      className={`px-3 py-1 bg-green-600 rounded min-tap ${props.className ?? ''}`}
     >
       Backup Seed
     </button>

--- a/shared/ui/BottomNav.tsx
+++ b/shared/ui/BottomNav.tsx
@@ -42,7 +42,7 @@ export const BottomNav: React.FC = () => {
           href="/"
           aria-label="Home"
           aria-current={path === '/' ? 'page' : undefined}
-          className="text-gray-900 dark:text-gray-100 focus:outline-none focus:ring"
+          className="text-gray-900 dark:text-gray-100 focus:outline-none focus:ring min-tap flex items-center justify-center"
           animate={{ scale: path === '/' ? 1.2 : 1 }}
           transition={{ type: 'spring', stiffness: 400, damping: 20 }}
         >
@@ -53,7 +53,7 @@ export const BottomNav: React.FC = () => {
           href="/discover"
           aria-label="Discover"
           aria-current={path === '/discover' ? 'page' : undefined}
-          className="text-gray-900 dark:text-gray-100 focus:outline-none focus:ring"
+          className="text-gray-900 dark:text-gray-100 focus:outline-none focus:ring min-tap flex items-center justify-center"
           animate={{ scale: path === '/discover' ? 1.2 : 1 }}
           transition={{ type: 'spring', stiffness: 400, damping: 20 }}
         >
@@ -64,7 +64,7 @@ export const BottomNav: React.FC = () => {
           href="/profile"
           aria-label="Profile"
           aria-current={path === '/profile' ? 'page' : undefined}
-          className="text-gray-900 dark:text-gray-100 focus:outline-none focus:ring"
+          className="text-gray-900 dark:text-gray-100 focus:outline-none focus:ring min-tap flex items-center justify-center"
           animate={{ scale: path === '/profile' ? 1.2 : 1 }}
           transition={{ type: 'spring', stiffness: 400, damping: 20 }}
         >

--- a/shared/ui/Button.tsx
+++ b/shared/ui/Button.tsx
@@ -7,7 +7,8 @@ import React from 'react';
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 export const Button: React.FC<ButtonProps> = ({ className = '', ...props }) => {
-  const base = 'rounded-lg px-4 py-3 bg-primary text-white hover:bg-primary disabled:opacity-50';
+  const base =
+    'rounded-lg px-4 py-3 bg-primary text-white hover:bg-primary disabled:opacity-50 min-tap';
   return <button className={`${base} ${className}`.trim()} {...props} />;
 };
 

--- a/shared/ui/CameraView.tsx
+++ b/shared/ui/CameraView.tsx
@@ -66,7 +66,7 @@ export const CameraView: React.FC<CameraViewProps> = ({ onCapture }) => {
           className={`w-full ${ready ? 'block' : 'hidden'}`}
         />
       </div>
-      <button className="mt-2" onClick={handleCapture}>
+      <button className="mt-2 min-tap" onClick={handleCapture}>
         Capture
       </button>
     </div>

--- a/shared/ui/CommentsDrawer.tsx
+++ b/shared/ui/CommentsDrawer.tsx
@@ -90,7 +90,7 @@ export const CommentsDrawer: React.FC<CommentsDrawerProps> = ({
             />
             <button
               type="submit"
-              className="rounded bg-purple-600 px-4 py-1"
+              className="rounded bg-purple-600 px-4 py-1 min-tap"
             >
               Send
             </button>

--- a/shared/ui/FollowBtn.tsx
+++ b/shared/ui/FollowBtn.tsx
@@ -18,7 +18,7 @@ export const FollowBtn: React.FC<FollowBtnProps> = ({ creatorId }) => {
 
   return (
     <button
-      className="px-3 py-1 rounded bg-primary text-sm"
+      className="px-3 py-1 rounded bg-primary text-sm min-tap"
       onClick={() => toggleFollow(creatorId)}
     >
       {isFollowing ? 'Unfollow' : 'Follow'}

--- a/shared/ui/InstallBanner.tsx
+++ b/shared/ui/InstallBanner.tsx
@@ -41,7 +41,7 @@ export const InstallBanner: React.FC<InstallBannerProps> = ({ onFinish }) => {
       <p className="mb-4">Add this app to your home screen.</p>
       <button
         onClick={install}
-        className="rounded bg-primary px-4 py-2"
+        className="rounded bg-primary px-4 py-2 min-tap"
         autoFocus
       >
         {deferred ? 'Install' : 'Continue'}

--- a/shared/ui/MintSelect.tsx
+++ b/shared/ui/MintSelect.tsx
@@ -33,7 +33,7 @@ export const MintSelect: React.FC<MintSelectProps> = ({ onNext }) => {
       />
       <button
         onClick={handleNext}
-        className="mt-4 rounded bg-primary px-4 py-2"
+        className="mt-4 rounded bg-primary px-4 py-2 min-tap"
       >
         Next
       </button>

--- a/shared/ui/Nav.tsx
+++ b/shared/ui/Nav.tsx
@@ -22,7 +22,7 @@ export const Nav: React.FC = () => {
         <ToggleDarkMode />
         <button
           onClick={() => setOpen(true)}
-          className="rounded bg-subtleBg dark:bg-surface-800 px-2 py-1 text-gray-900 dark:text-gray-100"
+          className="rounded bg-subtleBg dark:bg-surface-800 px-2 py-1 text-gray-900 dark:text-gray-100 min-tap"
         >
           Wallet
         </button>

--- a/shared/ui/PostMenu.tsx
+++ b/shared/ui/PostMenu.tsx
@@ -43,7 +43,7 @@ export const PostMenu: React.FC<PostMenuProps> = ({
       <button
         aria-label="Open post menu"
         onClick={() => setOpen((o) => !o)}
-        className="p-2"
+        className="p-2 min-tap"
       >
         ⋮
       </button>
@@ -51,13 +51,13 @@ export const PostMenu: React.FC<PostMenuProps> = ({
         <div className="absolute right-0 z-10 mt-2 w-40 rounded-md bg-surface-100 dark:bg-surface-800 shadow-lg ring-1 ring-black/5">
           <div className="py-1">
             <button
-              className="block w-full px-4 py-2 text-left text-sm hover:bg-subtleBg"
+              className="block w-full px-4 py-2 text-left text-sm hover:bg-subtleBg min-h-11"
               onClick={() => setReportOpen(true)}
             >
               Report
             </button>
             <button
-              className="block w-full px-4 py-2 text-left text-sm hover:bg-subtleBg"
+              className="block w-full px-4 py-2 text-left text-sm hover:bg-subtleBg min-h-11"
               onClick={handleBlock}
             >
               Block author
@@ -70,7 +70,7 @@ export const PostMenu: React.FC<PostMenuProps> = ({
           {reasons.map((r) => (
             <button
               key={r}
-              className="block w-full rounded p-2 text-left hover:bg-subtleBg"
+              className="block w-full rounded p-2 text-left hover:bg-subtleBg min-h-11"
               onClick={() => handleReport(r)}
             >
               {r}

--- a/shared/ui/PublishBtn.tsx
+++ b/shared/ui/PublishBtn.tsx
@@ -26,7 +26,7 @@ export const PublishBtn: React.FC<PublishBtnProps> = ({ magnet, onPublish }) => 
       <button
         disabled={!magnet}
         onClick={handleClick}
-        className="px-4 py-2 bg-primary rounded disabled:bg-surface-100 dark:disabled:bg-surface-800"
+        className="px-4 py-2 bg-primary rounded disabled:bg-surface-100 dark:disabled:bg-surface-800 min-tap"
       >
         Publish
       </button>

--- a/shared/ui/RefillBtn.tsx
+++ b/shared/ui/RefillBtn.tsx
@@ -27,7 +27,7 @@ export const RefillBtn: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> 
       <button
         {...props}
         onClick={handleClick}
-        className={`px-3 py-1 bg-primary rounded ${props.className ?? ''}`}
+        className={`px-3 py-1 bg-primary rounded min-tap ${props.className ?? ''}`}
       >
         Refill
       </button>

--- a/shared/ui/Timeline.tsx
+++ b/shared/ui/Timeline.tsx
@@ -63,7 +63,11 @@ export const Timeline: React.FC = () => {
   return (
     <div className="relative flex h-screen flex-col">
       <header className="flex justify-end p-2">
-        <button onClick={() => setWalletOpen(true)}>
+        <button
+          onClick={() => setWalletOpen(true)}
+          aria-label="Open wallet"
+          className="min-tap"
+        >
           <BalanceChip />
         </button>
       </header>

--- a/shared/ui/TimelineCard.tsx
+++ b/shared/ui/TimelineCard.tsx
@@ -91,7 +91,7 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({
           <div className={`flex items-center justify-between p-4 ${text ? 'mb-[-8px]' : ''}`}>
             <button
               type="button"
-              className="flex items-center gap-2"
+              className="flex items-center gap-2 min-tap"
               onClick={(e) => {
                 e.stopPropagation();
                 if (authorPubKey) setProfileOpen(true);
@@ -114,6 +114,7 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({
                     e.stopPropagation();
                     setCommentsOpen(true);
                   }}
+                  className="flex items-center justify-center min-tap"
                 >
                   <MessageCircle className="h-5 w-5" />
                 </button>

--- a/shared/ui/ToggleDarkMode.tsx
+++ b/shared/ui/ToggleDarkMode.tsx
@@ -32,7 +32,7 @@ export const ToggleDarkMode: React.FC<React.ButtonHTMLAttributes<HTMLButtonEleme
         props.onClick?.(e);
         setDark((d) => !d);
       }}
-      className={`px-2 py-1 rounded bg-subtleBg text-gray-900 dark:bg-surface-800 dark:text-gray-100 ${
+      className={`px-2 py-1 rounded bg-subtleBg text-gray-900 dark:bg-surface-800 dark:text-gray-100 min-tap ${
         props.className ?? ''
       }`}
     >

--- a/shared/ui/WalletModal.tsx
+++ b/shared/ui/WalletModal.tsx
@@ -26,7 +26,7 @@ export const WalletModal: React.FC<WalletModalProps> = ({ open, onOpenChange }) 
           <button
             onClick={() => onOpenChange(false)}
             aria-label="Close wallet"
-            className="rounded bg-subtleBg px-2 py-1"
+            className="rounded bg-subtleBg px-2 py-1 min-tap"
           >
             Close
           </button>

--- a/shared/ui/ZapButton.tsx
+++ b/shared/ui/ZapButton.tsx
@@ -64,7 +64,7 @@ const ZapOption: React.FC<{
 
   return (
     <button
-      className="px-2 py-1 bg-purple-600 rounded disabled:opacity-50"
+      className="px-2 py-1 bg-purple-600 rounded disabled:opacity-50 min-tap"
       disabled={disabled || balance < amount}
       onPointerDown={handlePointerDown}
       onPointerUp={handlePointerUp}


### PR DESCRIPTION
## Summary
- ensure action buttons have 44px touch targets
- add aria labels or visible text for icon-only buttons
- update nav links and wallet access to use min-tap sizing

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689081c08dec8331b085e00d7612254f