### PR TITLE
chore(web): dedupe libsodium wrappers

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
     },
   },
   resolve: {
+    dedupe: ['libsodium-wrappers', 'libsodium-wrappers-sumo'],
     alias: {
       path: path.resolve(__dirname, 'path-shim.ts'),
       // stub fs for browser compatibility


### PR DESCRIPTION
## Summary
- dedupe libsodium-wrappers modules in web Vite config

## Testing
- `pnpm lint`
- `pnpm test` *(fails: No "initSsb" export is defined on the "../../worker-ssb/src/instance" mock)*

------
https://chatgpt.com/codex/tasks/task_e_6890918ace988331a17405c3fff217a0