### PR TITLE
chore: dedupe libsodium in worker-ssb Vite config

### DIFF
--- a/packages/worker-ssb/vite.config.ts
+++ b/packages/worker-ssb/vite.config.ts
@@ -11,6 +11,7 @@ import ssbReservedWordsFix, {
 export default defineConfig({
   plugins: [ssbReservedWordsFix()],
   resolve: {
+    dedupe: ['libsodium-wrappers', 'libsodium-wrappers-sumo'],
     alias: {
       // Stub fs to prevent node filesystem access in the worker bundle
       fs: path.resolve(__dirname, 'empty-fs.js'),


### PR DESCRIPTION
## Summary
- dedupe libsodium wrappers in worker-ssb Vite resolve config

## Testing
- `pnpm lint packages/worker-ssb/vite.config.ts`
- `pnpm test` *(fails: No "initSsb" export defined in mock)*

------
https://chatgpt.com/codex/tasks/task_e_6890926b4814833195e60e7f714203c9