### PR TITLE
chore: add libsodium resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,10 @@
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"
   },
+  "resolutions": {
+    "libsodium-wrappers": "latest",
+    "libsodium-wrappers-sumo": "latest"
+  },
   "pnpm": {
     "overrides": {
       "random-access-chrome-file": "npm:random-access-idb@^1.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  libsodium-wrappers: latest
+  libsodium-wrappers-sumo: latest
   random-access-chrome-file: npm:random-access-idb@^1.2.2
 
 patchedDependencies:
@@ -47,7 +49,7 @@ importers:
         specifier: ^12.23.12
         version: 12.23.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       libsodium-wrappers-sumo:
-        specifier: ^0.7.15
+        specifier: latest
         version: 0.7.15
       lucide-react:
         specifier: ^0.536.0


### PR DESCRIPTION
## Summary
- pin libsodium-wrappers packages to latest via resolutions
- update lockfile

## Testing
- `pnpm install`
- `pnpm test` *(fails: packages/integration/__tests__/flow.test.ts > integration flow > seeds, publishes, streams and zaps)*

------
https://chatgpt.com/codex/tasks/task_e_6890935b3dec8331bf27a5c1db900056