### PR TITLE
refactor: use namespace import for libsodium

### DIFF
--- a/packages/worker-ssb/src/index.ts
+++ b/packages/worker-ssb/src/index.ts
@@ -1,4 +1,4 @@
-import sodium from 'libsodium-wrappers-sumo';
+import * as sodium from 'libsodium-wrappers-sumo';
 import { init as createBrowserSsb } from 'ssb-browser-core/net.js';
 import randomAccessIdb from 'random-access-idb';
 


### PR DESCRIPTION
## Summary
- use namespace import for libsodium in worker-ssb
- keep sodium.ready check

## Testing
- `pnpm lint packages/worker-ssb/src/index.ts`
- `pnpm test packages/worker-ssb`


------
https://chatgpt.com/codex/tasks/task_e_68909b9d1c3883318c074290ea53a436