### PR TITLE
Use random-access-idb for SSB blobs

### DIFF
--- a/packages/worker-ssb/src/index.ts
+++ b/packages/worker-ssb/src/index.ts
@@ -1,6 +1,6 @@
 import * as sodium from 'libsodium-wrappers-sumo';
 import { init as createBrowserSsb } from 'ssb-browser-core/net.js';
-import randomAccessIdb from 'random-access-idb';
+import randomAccessIDB from 'random-access-idb';
 
 let ssb: any;
 
@@ -9,7 +9,7 @@ export async function initSsb() {
   await sodium.ready;
   try {
     ssb = createBrowserSsb('cashucast-ssb', {
-      storage: randomAccessIdb,
+      storage: randomAccessIDB,
       crypto: {
         sign: sodium.crypto_sign_detached,
         verify: sodium.crypto_sign_open_detached,
@@ -17,6 +17,7 @@ export async function initSsb() {
         openSecretbox: sodium.crypto_secretbox_open_easy,
       },
     });
+    ssb.blobs.use(randomAccessIDB);
   } catch (err) {
     // Fallback stub for environments without IndexedDB
     ssb = {


### PR DESCRIPTION
## Summary
- store SSB data in IndexedDB and hook blobs API to random-access-idb

## Testing
- `pnpm test` *(fails: Cannot set property navigator of #<Object> which has only a getter)*

------
https://chatgpt.com/codex/tasks/task_e_6891072487b48331a51be5c03351bdd4