### PR TITLE
refactor: statically import libsodium

### DIFF
--- a/apps/web/src/boot/ssbClient.ts
+++ b/apps/web/src/boot/ssbClient.ts
@@ -4,12 +4,12 @@
 */
 import { init as createBrowserSsb } from 'ssb-browser-core/net.js';
 import randomAccessIdb from 'random-access-idb';
+import * as sodium from 'libsodium-wrappers-sumo';
 
 let ssb: any;
 
 export async function initSsb() {
   if (ssb) return ssb;
-  const sodium = await import('libsodium-wrappers-sumo').then(m => m);
   await sodium.ready;
   try {
     ssb = createBrowserSsb('cashucast-ssb', {


### PR DESCRIPTION
## Summary
- statically import libsodium in web SSB client
- await libsodium initialization before using sodium APIs

## Testing
- `pnpm test` *(fails: No `initSsb` export is defined on the `../../worker-ssb/src/instance` mock)*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6891070ce454833198721db6eb684d76