### PR TITLE
Publish profile to SSB during onboarding

### DIFF
--- a/apps/web/src/routes/Onboarding.test.tsx
+++ b/apps/web/src/routes/Onboarding.test.tsx
@@ -41,6 +41,8 @@ vi.mock('react-easy-crop', () => ({
 
 vi.mock('../../../../packages/worker-ssb/src/instance', () => ({
   getSSB: () => ({
+    id: 'test-id',
+    publish: (_msg: any, cb: any) => cb && cb(null),
     blobs: {
       add: () => ({
         write: () => {},

--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -200,6 +200,22 @@ function OnboardingContent() {
     } else if (mode === 'import' && profile) {
       setProfile(profile);
     }
+    const ssb = getSSB();
+    try {
+      await new Promise<void>((resolve, reject) =>
+        ssb.publish(
+          {
+            type: 'about',
+            about: ssb.id,
+            name: username,
+            ...(avatarHash ? { image: avatarHash } : {}),
+          },
+          (err: any) => (err ? reject(err) : resolve()),
+        ),
+      );
+    } catch (err) {
+      console.warn('Failed to publish profile', err);
+    }
     setToast(true);
     window.history.pushState(null, '', '/');
     window.dispatchEvent(new PopStateEvent('popstate'));


### PR DESCRIPTION
## Summary
- publish SSB `about` message after profile creation/import with optional avatar
- handle publish errors so onboarding continues
- mock SSB `publish` in tests

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68911ba8e4d48331a24ca47fe9c1c9e9