### PR TITLE
feat: guard libsodium document access

### DIFF
--- a/scripts/patch-libsodium.mjs
+++ b/scripts/patch-libsodium.mjs
@@ -14,7 +14,7 @@ try {
 
 let content = readFileSync(libsodiumPath, 'utf8');
 const target = 'document.currentScript&&(c=document.currentScript.src),c=c.startsWith("blob:")?"":c.substr(0,c.replace(/[?#].*/,"").lastIndexOf("/")+1)';
-const replacement = 'document.currentScript&&(c=document.currentScript.src),c="string"==typeof c?c.startsWith("blob:")?"":c.substr(0,c.replace(/[?#].*/,"").lastIndexOf("/")+1):""';
+const replacement = 'typeof document!="undefined"&&document.currentScript&&(c=document.currentScript.src),c="string"==typeof c?c.startsWith("blob:")?"":c.substr(0,c.replace(/[?#].*/,"").lastIndexOf("/")+1):""';
 if (content.includes(replacement)) {
   console.log('libsodium already patched');
   process.exit(0);


### PR DESCRIPTION
## Summary
- guard libsodium patch against missing `document.currentScript`

## Testing
- `node scripts/patch-libsodium.mjs`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689123e4c34c8331bf805322b0d35499