### PR TITLE
fix: load libsodium base module explicitly

### DIFF
--- a/apps/web/src/boot/ssbClient.ts
+++ b/apps/web/src/boot/ssbClient.ts
@@ -6,7 +6,8 @@ import { init as createBrowserSsb } from 'ssb-browser-core/net.js';
 import randomAccessIdb from 'random-access-idb';
 import ssbBlobStore from 'ssb-blob-store';
 import { Buffer } from 'buffer';
-import * as sodium from 'libsodium-wrappers-sumo';
+import 'libsodium-sumo';
+import sodium from 'libsodium-wrappers-sumo';
 import { cache as blobCache, prune } from '../../../../packages/worker-ssb/src/blobCache';
 
 let ssb: any;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "worker-dom": "^0.1.0",
     "wrtc": "^0.4.7",
     "zod": "^4.0.14",
-    "zustand": "^5.0.7"
+    "zustand": "^5.0.7",
+    "libsodium-sumo": "^0.7.15"
   },
   "devDependencies": {
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",

--- a/packages/worker-ssb/src/index.ts
+++ b/packages/worker-ssb/src/index.ts
@@ -1,4 +1,5 @@
-import * as sodium from 'libsodium-wrappers-sumo';
+import 'libsodium-sumo';
+import sodium from 'libsodium-wrappers-sumo';
 import ssbFriends from 'ssb-friends';
 import ssbSearch2 from 'ssb-search2';
 import { init as createBrowserSsb } from 'ssb-browser-core/net.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       framer-motion:
         specifier: ^12.23.12
         version: 12.23.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      libsodium-sumo:
+        specifier: ^0.7.15
+        version: 0.7.15
       libsodium-wrappers-sumo:
         specifier: latest
         version: 0.7.15

--- a/shared/types/libsodium-wrappers-sumo.d.ts
+++ b/shared/types/libsodium-wrappers-sumo.d.ts
@@ -1,4 +1,4 @@
 declare module 'libsodium-wrappers-sumo' {
   const mod: typeof import('libsodium-wrappers');
-  export = mod;
+  export default mod;
 }


### PR DESCRIPTION
## Summary
- load `libsodium-sumo` before `libsodium-wrappers-sumo` so the wrapper can access the base module
- add `libsodium-sumo` dependency and types for default import

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6891c212e61883318b7b325c5bf8b377