### PR TITLE
feat: configure SSB app key via env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      SSB_APP_KEY: ${{ secrets.SSB_APP_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+          run_install: true
+      - run: pnpm lint
+      - run: pnpm test
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 /tmp/
+.env
+apps/web/.env

--- a/README.md
+++ b/README.md
@@ -62,9 +62,12 @@ starting so changes are always picked up on launch.
 
 ### Environment variables
 
-The development server recognises a few optional variables for overriding network endpoints:
+Create an `.env` file in `apps/web` to configure the web app and SSB worker:
 
+- `SSB_APP_KEY` – Base64-encoded capability string used to join the Secure Scuttlebutt network. This value must match the room server's app key.
 - `VITE_DHT_URL` – WebSocket URL of the DHT bootstrap node. Defaults to `ws://localhost:6881`.
+
+An example file is provided at `apps/web/.env.example`.
 
 ## Running tests
 
@@ -86,6 +89,8 @@ curl -sL https://raw.githubusercontent.com/<your-org>/cashucast/main/scripts/ins
 
 The script installs Caddy, a container runtime, fetches this repository and launches the production Docker
 Compose stack located under `infra/docker`.
+
+Set the `SSB_APP_KEY` environment variable (base64 encoded) before building or deploying the web app. In CI, store this value as a secret named `SSB_APP_KEY`.
 
 ## Helper scripts
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,3 @@
+## Base64-encoded app key for Secure Scuttlebutt connections
+SSB_APP_KEY=
+

--- a/infra/docker/README.md
+++ b/infra/docker/README.md
@@ -1,0 +1,8 @@
+# Deployment
+
+The Docker compose files in this directory launch the supporting services for CashuCast.
+
+## Environment variables
+
+Set `SSB_APP_KEY` to the base64-encoded capability string used by the Secure Scuttlebutt network before building or deploying the web application. The same value should be provided to the CI workflow as the `SSB_APP_KEY` secret.
+

--- a/packages/worker-ssb/src/index.ts
+++ b/packages/worker-ssb/src/index.ts
@@ -37,7 +37,7 @@ export async function initSsb() {
       },
       friends: { hops: 2 },
       replication: { legacy: false },
-      caps: { shs: Buffer.from('<YOUR_APP_KEY>', 'base64') },
+      caps: { shs: Buffer.from(process.env.SSB_APP_KEY!, 'base64') },
     });
   } catch (err) {
     // Fallback stub for environments without IndexedDB

--- a/scripts/install_server.sh
+++ b/scripts/install_server.sh
@@ -3,6 +3,8 @@
 # Usage (as root):  curl -sL https://raw.githubusercontent.com/<your-org>/cashucast/main/scripts/install_server.sh | bash
 set -e
 
+: "${SSB_APP_KEY:?SSB_APP_KEY environment variable must be set}"
+
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-$(command -v podman >/dev/null 2>&1 && echo podman || echo docker)}
 
 BASE_PKGS="caddy ufw fail2ban git"


### PR DESCRIPTION
## Summary
- read SSB app key from environment
- document SSB_APP_KEY and provide example env file
- require SSB_APP_KEY for deployment and CI

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6891ca793db883318384defce527e56b