### PR TITLE
feat: copy libsodium wasm into builds

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -10,9 +10,32 @@ import ssbReservedWordsFix, {
 import path from 'path';
 import tailwindcss from 'tailwindcss';
 import autoprefixer from 'autoprefixer';
+import { copyFileSync, existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+function copyLibsodiumWasm() {
+  let outDir: string;
+  return {
+    name: 'copy-libsodium-wasm',
+    configResolved(config) {
+      outDir = config.build.outDir;
+    },
+    closeBundle() {
+      const source = fileURLToPath(
+        new URL(
+          '../../node_modules/libsodium-wrappers-sumo/dist/modules-sumo/libsodium-sumo.wasm',
+          import.meta.url,
+        ),
+      );
+      if (existsSync(source)) {
+        copyFileSync(source, path.resolve(outDir, 'libsodium-sumo.wasm'));
+      }
+    },
+  };
+}
 
 export default defineConfig({
-  plugins: [ssbReservedWordsFix(), react()],
+  plugins: [ssbReservedWordsFix(), react(), copyLibsodiumWasm()],
   css: {
     postcss: {
       plugins: [

--- a/packages/worker-ssb/vite.config.ts
+++ b/packages/worker-ssb/vite.config.ts
@@ -9,12 +9,36 @@ import ssbReservedWordsFix, {
 } from '../../ssb-reserved-words-fix';
 import { NodeGlobalsPolyfillPlugin } from '@esbuild-plugins/node-globals-polyfill';
 import { NodeModulesPolyfillPlugin } from '@esbuild-plugins/node-modules-polyfill';
+import { copyFileSync, existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+function copyLibsodiumWasm() {
+  let outDir: string;
+  return {
+    name: 'copy-libsodium-wasm',
+    configResolved(config) {
+      outDir = config.build.outDir;
+    },
+    closeBundle() {
+      const source = fileURLToPath(
+        new URL(
+          '../../node_modules/libsodium-wrappers-sumo/dist/modules-sumo/libsodium-sumo.wasm',
+          import.meta.url,
+        ),
+      );
+      if (existsSync(source)) {
+        copyFileSync(source, path.resolve(outDir, 'libsodium-sumo.wasm'));
+      }
+    },
+  };
+}
 
 export default defineConfig({
   plugins: [
     ssbReservedWordsFix(),
     NodeGlobalsPolyfillPlugin({ buffer: true, process: true }),
     NodeModulesPolyfillPlugin(),
+    copyLibsodiumWasm(),
   ],
   define: { global: 'globalThis' },
   resolve: {


### PR DESCRIPTION
## Summary
- copy libsodium wasm into web build
- copy libsodium wasm into worker build

## Testing
- `npm run test`
- `NODE_OPTIONS=--max_old_space_size=4096 pnpm --filter web build`
- `NODE_OPTIONS=--max_old_space_size=4096 pnpm --filter web exec vite build packages/worker-ssb` *(fails: Could not resolve entry module "packages/worker-ssb/index.html".)*
- `node -e "import('libsodium-wrappers-sumo').then(async (s) => {await s.ready; console.log('sodium ready');})"`


------
https://chatgpt.com/codex/tasks/task_e_6891d00fcf048331990ca0e4519af1f3