### PR TITLE
chore: pin libsodium wrapper versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "vitest": "^3.2.4"
   },
   "resolutions": {
-    "libsodium-wrappers": "latest",
-    "libsodium-wrappers-sumo": "latest"
+    "libsodium-wrappers": "0.7.15",
+    "libsodium-wrappers-sumo": "0.7.15"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  libsodium-wrappers: latest
-  libsodium-wrappers-sumo: latest
+  libsodium-wrappers: 0.7.15
+  libsodium-wrappers-sumo: 0.7.15
   random-access-chrome-file: npm:random-access-idb@^1.2.2
 
 patchedDependencies:
@@ -52,7 +52,7 @@ importers:
         specifier: ^0.7.15
         version: 0.7.15
       libsodium-wrappers-sumo:
-        specifier: latest
+        specifier: 0.7.15
         version: 0.7.15
       lucide-react:
         specifier: ^0.536.0


### PR DESCRIPTION
## Summary
- pin libsodium-wrappers and libsodium-wrappers-sumo to 0.7.15
- regenerate pnpm lockfile

## Testing
- `pnpm install`
- `node scripts/patch-libsodium.mjs`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6891db4f9d94833195f7a5df27f87777