### PR TITLE
Handle libsodium initialization failures

### DIFF
--- a/packages/worker-ssb/__tests__/sodiumFail.test.ts
+++ b/packages/worker-ssb/__tests__/sodiumFail.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Licensed under GPL-3.0-or-later
+ * Tests that initSsb handles libsodium initialization failures.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+const sodiumError = new Error('boom');
+vi.mock('libsodium-sumo', () => ({}));
+const ready = Promise.reject(sodiumError);
+ready.catch(() => {});
+vi.mock('libsodium-wrappers-sumo', () => ({ ready }));
+
+describe('initSsb sodium failure', () => {
+  it('logs an error and returns a stub SSB instance', async () => {
+    vi.resetModules();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { initSsb } = await import('../src/index');
+    const ssb = await initSsb();
+    expect(ssb).toBeTruthy();
+    expect(ssb.blobs).toBeDefined();
+    expect(typeof ssb.blobs.add).toBe('function');
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError.mock.calls[0][0]).toBe(
+      'Failed to initialize libsodium. SSB features are disabled.'
+    );
+    expect(consoleError.mock.calls[0][1]).toBe(sodiumError);
+    consoleError.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- guard `libsodium.ready` with try/catch in worker SSB init and return stub instance on failure
- add tests covering libsodium initialization failure path

## Testing
- `pnpm lint packages/worker-ssb/src/index.ts packages/worker-ssb/__tests__/sodiumFail.test.ts`
- `pnpm test packages/worker-ssb`


------
https://chatgpt.com/codex/tasks/task_e_6891dceaa1f08331962634fda6d12550