### PR TITLE
feat: verify libsodium wasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ Create an `.env` file in `apps/web` to configure the web app and SSB worker:
 
 An example file is provided at `apps/web/.env.example`.
 
+### libsodium WASM file
+
+Both the web app and the SSB worker depend on the `libsodium-sumo.wasm` binary from
+`libsodium-wrappers-sumo`. A Vite plugin copies this file to the output directory
+and verifies that the copy exists. The check runs in development and production:
+missing files trigger a warning during `vite dev` and cause production builds to
+fail.
+
 ## Running tests
 
 Unit tests can be run with the helper script:

--- a/packages/worker-ssb/vite.config.ts
+++ b/packages/worker-ssb/vite.config.ts
@@ -14,20 +14,39 @@ import { fileURLToPath } from 'url';
 
 function copyLibsodiumWasm() {
   let outDir: string;
+  let rootDir: string;
+  const filename = 'libsodium-sumo.wasm';
+  const source = fileURLToPath(
+    new URL(
+      '../../node_modules/libsodium-wrappers-sumo/dist/modules-sumo/libsodium-sumo.wasm',
+      import.meta.url,
+    ),
+  );
   return {
     name: 'copy-libsodium-wasm',
     configResolved(config) {
       outDir = config.build.outDir;
+      rootDir = config.root;
+    },
+    configureServer() {
+      const dest = path.resolve(rootDir, filename);
+      if (!existsSync(source)) {
+        console.warn(`missing ${filename} at ${source}`);
+        return;
+      }
+      copyFileSync(source, dest);
+      if (!existsSync(dest)) {
+        console.warn(`failed to copy ${filename} to dev output`);
+      }
     },
     closeBundle() {
-      const source = fileURLToPath(
-        new URL(
-          '../../node_modules/libsodium-wrappers-sumo/dist/modules-sumo/libsodium-sumo.wasm',
-          import.meta.url,
-        ),
-      );
-      if (existsSync(source)) {
-        copyFileSync(source, path.resolve(outDir, 'libsodium-sumo.wasm'));
+      const dest = path.resolve(outDir, filename);
+      if (!existsSync(source)) {
+        this.error(`missing ${filename} at ${source}`);
+      }
+      copyFileSync(source, dest);
+      if (!existsSync(dest)) {
+        this.error(`failed to copy ${filename} to ${dest}`);
       }
     },
   };


### PR DESCRIPTION
## Summary
- ensure `libsodium-sumo.wasm` is copied for dev and build and warn/fail when missing
- document wasm copy check for contributors

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6891e06394088331adb90d3aafcc9b6d