### PR TITLE
fix: avoid bundling libsodium-sumo

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -97,7 +97,7 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    exclude: ['libsodium-wrappers-sumo'],
+    exclude: ['libsodium-wrappers-sumo', 'libsodium-sumo'],
     esbuildOptions: {
       plugins: [ssbReservedWordsFixEsbuild()],
     },

--- a/packages/worker-ssb/vite.config.ts
+++ b/packages/worker-ssb/vite.config.ts
@@ -72,7 +72,7 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    exclude: ['libsodium-wrappers-sumo'],
+    exclude: ['libsodium-wrappers-sumo', 'libsodium-sumo'],
     esbuildOptions: {
       plugins: [
         ssbReservedWordsFixEsbuild(),


### PR DESCRIPTION
## Summary
- exclude libsodium-sumo from Vite dependency optimization for web and worker builds

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6891e264964c83318be0dad73bdd4673