### PR TITLE
chore: remove libsodium-sumo import

### DIFF
--- a/packages/worker-ssb/__tests__/sodiumFail.test.ts
+++ b/packages/worker-ssb/__tests__/sodiumFail.test.ts
@@ -5,7 +5,6 @@
 import { describe, it, expect, vi } from 'vitest';
 
 const sodiumError = new Error('boom');
-vi.mock('libsodium-sumo', () => ({}));
 const ready = Promise.reject(sodiumError);
 ready.catch(() => {});
 vi.mock('libsodium-wrappers-sumo', () => ({ ready }));

--- a/packages/worker-ssb/src/index.ts
+++ b/packages/worker-ssb/src/index.ts
@@ -1,4 +1,3 @@
-import 'libsodium-sumo';
 import * as sodium from 'libsodium-wrappers-sumo';
 import ssbFriends from 'ssb-friends';
 import ssbSearch2 from 'ssb-search2';


### PR DESCRIPTION
## Summary
- simplify SSB worker initialization by dropping direct libsodium-sumo import
- clean up sodium failure test mocking

## Testing
- `CI=1 pnpm test`
- `pnpm --filter web build` *(fails: Exit status 143)*

------
https://chatgpt.com/codex/tasks/task_e_6891e54b7d488331aa2034ebcb9492e5