### PR TITLE
feat: use MUI BottomNavigation

### DIFF
--- a/shared/ui/BottomNav.test.tsx
+++ b/shared/ui/BottomNav.test.tsx
@@ -11,11 +11,10 @@ describe('BottomNav', () => {
   it('renders navigation links', () => {
     const html = renderToStaticMarkup(<BottomNav />);
     expect(html).toContain('Home');
-    expect(html).toContain('href="/discover"');
-    expect(html).not.toContain('href="/record"');
-    expect(html).toContain('+');
+    expect(html).toContain('Discover');
     expect(html).toContain('Profile');
-    expect(html).toContain('aria-current="page"');
+    expect(html).toContain('+');
+    expect(html).toContain('Mui-selected');
   });
 
   it('hides on wider screens', () => {

--- a/shared/ui/BottomNav.tsx
+++ b/shared/ui/BottomNav.tsx
@@ -3,29 +3,23 @@
  * React component for BottomNav.
  */
 import React from 'react';
+import BottomNavigation from '@mui/material/BottomNavigation';
+import BottomNavigationAction from '@mui/material/BottomNavigationAction';
+import HomeRounded from '@mui/icons-material/HomeRounded';
+import ExploreRounded from '@mui/icons-material/ExploreRounded';
+import PersonRounded from '@mui/icons-material/PersonRounded';
 import FabRecord from './FabRecord';
-import { Compass, Home, User } from 'lucide-react';
-import { motion, useReducedMotion } from 'framer-motion';
-import { prefersReducedMotion } from './prefersReducedMotion';
 
-/** Bottom navigation bar that hides on scroll down.
- * Visible only on screens up to 600px wide.
+/**
+ * Material 3 navigation bar using MUI BottomNavigation.
+ * Spec: https://m3.material.io/components/navigation-bar/overview
+ * Docs: https://mui.com/material-ui/react-bottom-navigation/
  */
 export const BottomNav: React.FC = () => {
-  const [hidden, setHidden] = React.useState(false);
-  const [path, setPath] = React.useState(
+  const [value, setValue] = React.useState(
     () => (typeof window !== 'undefined' ? window.location.pathname : '/')
   );
-  const reduceMotion = useReducedMotion();
-  const transition = prefersReducedMotion(reduceMotion, {
-    type: 'spring',
-    stiffness: 400,
-    damping: 20,
-  });
-  const scaleStyle = (target: string) =>
-    reduceMotion ? { scale: path === target ? 1.2 : 1 } : undefined;
-  const animateScale = (target: string) =>
-    prefersReducedMotion(reduceMotion, { scale: path === target ? 1.2 : 1 });
+  const [hidden, setHidden] = React.useState(false);
 
   React.useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -35,7 +29,7 @@ export const BottomNav: React.FC = () => {
       setHidden(currentY > lastY);
       lastY = currentY;
     };
-    const onPopState = () => setPath(window.location.pathname);
+    const onPopState = () => setValue(window.location.pathname);
     window.addEventListener('scroll', onScroll);
     window.addEventListener('popstate', onPopState);
     return () => {
@@ -44,48 +38,42 @@ export const BottomNav: React.FC = () => {
     };
   }, []);
 
+  const handleChange = (_: React.SyntheticEvent, newValue: string) => {
+    if (newValue === value) return;
+    setValue(newValue);
+    window.history.pushState(null, '', newValue);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  };
+
   return (
     <>
-      <nav
-        className={`fixed bottom-0 left-0 right-0 flex justify-around bg-subtleBg dark:bg-surface-800 p-2 transition-transform duration-300 motion-reduce:transition-none sm:hidden ${hidden ? 'translate-y-full' : ''}`}
+      <BottomNavigation
+        value={value}
+        onChange={handleChange}
+        showLabels
+        className={`fixed bottom-0 left-0 right-0 sm:hidden transition-transform duration-300 bg-subtleBg dark:bg-surface-800 ${
+          hidden ? 'translate-y-full' : ''
+        }`}
       >
-        <motion.a
-          href="/"
-          aria-label="Home"
-          aria-current={path === '/' ? 'page' : undefined}
-          className="text-gray-900 dark:text-gray-100 focus:outline-none focus:ring min-tap flex items-center justify-center"
-          animate={animateScale('/')}
-          transition={transition}
-          style={scaleStyle('/')}
-        >
-          <Home className="mx-auto" />
-          <span className="sr-only">Home</span>
-        </motion.a>
-        <motion.a
-          href="/discover"
-          aria-label="Discover"
-          aria-current={path === '/discover' ? 'page' : undefined}
-          className="text-gray-900 dark:text-gray-100 focus:outline-none focus:ring min-tap flex items-center justify-center"
-          animate={animateScale('/discover')}
-          transition={transition}
-          style={scaleStyle('/discover')}
-        >
-          <Compass className="mx-auto" />
-          <span className="sr-only">Discover</span>
-        </motion.a>
-        <motion.a
-          href="/profile"
-          aria-label="Profile"
-          aria-current={path === '/profile' ? 'page' : undefined}
-          className="text-gray-900 dark:text-gray-100 focus:outline-none focus:ring min-tap flex items-center justify-center"
-          animate={animateScale('/profile')}
-          transition={transition}
-          style={scaleStyle('/profile')}
-        >
-          <User className="mx-auto" />
-          <span className="sr-only">Profile</span>
-        </motion.a>
-      </nav>
+        <BottomNavigationAction
+          label="Home"
+          value="/"
+          icon={<HomeRounded />}
+          className="text-gray-900 dark:text-gray-100"
+        />
+        <BottomNavigationAction
+          label="Discover"
+          value="/discover"
+          icon={<ExploreRounded />}
+          className="text-gray-900 dark:text-gray-100"
+        />
+        <BottomNavigationAction
+          label="Profile"
+          value="/profile"
+          icon={<PersonRounded />}
+          className="text-gray-900 dark:text-gray-100"
+        />
+      </BottomNavigation>
       <FabRecord />
     </>
   );

--- a/shared/ui/Timeline.test.tsx
+++ b/shared/ui/Timeline.test.tsx
@@ -12,6 +12,6 @@ describe('Timeline', () => {
     const html = renderToStaticMarkup(<Timeline />);
     expect(html).toContain('max-w-screen-md');
     expect(html).toContain('backdrop-blur');
-    expect(html).toContain('aria-label="Home"');
+    expect(html).toContain('Home');
   });
 });


### PR DESCRIPTION
## Summary
- replace custom bottom nav with MUI `BottomNavigation` and `BottomNavigationAction`
- map routes to actions and add Material 3 spec and MUI docs references
- adjust tests for updated navigation markup

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6892565a2968833199cbd4ea70d3efe5