### PR TITLE
refactor: use Material 3 color tokens

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -14,7 +14,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet" />
   <title>CashuCast</title>
 </head>
-<body class="bg-surface-100 text-on-surface font-sans dark:bg-surface-800 dark:text-on-surface-dark">
+<body class="bg-background text-on-surface font-sans dark:bg-background-dark dark:text-on-surface-dark">
   <div id="root"></div>
   <script type="module" src="/src/main.tsx"></script>
 </body>

--- a/apps/web/src/components/CommentsDrawer.tsx
+++ b/apps/web/src/components/CommentsDrawer.tsx
@@ -52,7 +52,7 @@ export const CommentsDrawer: React.FC<CommentsDrawerProps> = ({
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-on-surface/50 dark:bg-on-surface-dark/50" />
-        <Dialog.Content className="fixed inset-x-0 bottom-0 flex max-h-[70vh] flex-col rounded-t-md bg-surface-100 dark:bg-surface-800 md:top-0 md:max-h-none md:h-screen">
+        <Dialog.Content className="fixed inset-x-0 bottom-0 flex max-h-[70vh] flex-col rounded-t-md bg-surface dark:bg-surface-dark md:top-0 md:max-h-none md:h-screen">
           <Dialog.Title className="p-4 text-lg font-semibold">Comments</Dialog.Title>
           <div className="flex-1 overflow-y-auto p-4 space-y-2">
             {comments.map((c, i) => (

--- a/apps/web/src/routes/Discover.tsx
+++ b/apps/web/src/routes/Discover.tsx
@@ -44,7 +44,7 @@ export default function Discover() {
           <button
             key={t.tag}
             onClick={() => onTag(t.tag)}
-            className="shrink-0 rounded-full bg-subtleBg px-3 py-1"
+            className="shrink-0 rounded-full bg-surface dark:bg-surface-dark px-3 py-1"
           >
             #{t.tag}
           </button>

--- a/apps/web/src/routes/Onboarding.tsx
+++ b/apps/web/src/routes/Onboarding.tsx
@@ -286,7 +286,7 @@ function OnboardingContent() {
               id="username"
               name="username"
               autoComplete="username"
-              className="mt-1 block w-full rounded border px-4 py-3 min-h-[44px] font-normal bg-surface-100 dark:bg-surface-800 text-on-surface dark:text-on-surface-dark placeholder:text-on-surface dark:placeholder:text-on-surface-dark"
+              className="mt-1 block w-full rounded border px-4 py-3 min-h-[44px] font-normal bg-surface dark:bg-surface-dark text-on-surface dark:text-on-surface-dark placeholder:text-on-surface dark:placeholder:text-on-surface-dark"
               placeholder="Username"
               value={username}
               onChange={(e) => {
@@ -348,7 +348,7 @@ function OnboardingContent() {
                 />
                   <div
                     aria-hidden="true"
-                    className="pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center bg-surface-100/60 text-gray-500 dark:bg-surface-800/60 dark:text-gray-300"
+                    className="pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center bg-surface/60 text-gray-500 dark:bg-surface-dark/60 dark:text-gray-300"
                   >
                     <Upload className="h-6 w-6 mb-1" />
                     <span className="text-xs text-center px-1">
@@ -365,7 +365,7 @@ function OnboardingContent() {
           {avatarSrc && !avatarPreview && (
             <div className="flex flex-col items-center">
               {/* Explicit sizing ensures Cropper renders correctly */}
-              <div className="relative w-64 h-64 bg-subtleBg mb-4">
+              <div className="relative w-64 h-64 bg-surface dark:bg-surface-dark mb-4">
                 <Cropper
                   image={avatarSrc}
                   crop={crop}
@@ -624,7 +624,7 @@ export default function Onboarding() {
           <Dialog.Description className="sr-only">
             Set up your profile to start using CashuCast
           </Dialog.Description>
-          <div className="w-full max-w-md max-h-[90vh] overflow-auto bg-surface-100 dark:bg-surface-800 text-on-surface dark:text-on-surface-dark rounded-xl p-6">
+          <div className="w-full max-w-md max-h-[90vh] overflow-auto bg-surface dark:bg-surface-dark text-on-surface dark:text-on-surface-dark rounded-xl p-6">
             <OnboardingContent />
           </div>
         </Dialog.Content>

--- a/apps/web/src/routes/SettingsOverlay.tsx
+++ b/apps/web/src/routes/SettingsOverlay.tsx
@@ -14,7 +14,7 @@ export default function SettingsOverlay() {
   return (
     <Dialog.Root open onOpenChange={(o) => { if (!o) window.history.back(); }}>
       <Dialog.Overlay className="fixed inset-0 bg-on-surface/50 dark:bg-on-surface-dark/50" />
-      <Dialog.Content className="fixed inset-0 flex flex-col bg-surface-100 dark:bg-surface-800">
+      <Dialog.Content className="fixed inset-0 flex flex-col bg-surface dark:bg-surface-dark">
         <header className="flex items-center justify-between border-b p-4">
           <h1 className="text-xl font-semibold">Settings</h1>
           <Dialog.Close aria-label="Close" className="text-xl">×</Dialog.Close>

--- a/shared/ui/Avatar.tsx
+++ b/shared/ui/Avatar.tsx
@@ -22,7 +22,7 @@ export const Avatar: React.FC<AvatarProps> = ({
 }) => {
   const dimension = typeof size === 'number' ? `${size}px` : size;
   const baseClass =
-    'flex items-center justify-center rounded-full bg-subtleBg overflow-hidden text-gray-600';
+    'flex items-center justify-center rounded-full bg-surface dark:bg-surface-dark overflow-hidden text-gray-600';
   return (
     <div
       className={`${baseClass} ${className ?? ''}`}

--- a/shared/ui/BottomNav.tsx
+++ b/shared/ui/BottomNav.tsx
@@ -51,7 +51,7 @@ export const BottomNav: React.FC = () => {
         value={value}
         onChange={handleChange}
         showLabels
-        className={`fixed bottom-0 left-0 right-0 sm:hidden transition-transform duration-300 bg-subtleBg dark:bg-surface-800 ${
+        className={`fixed bottom-0 left-0 right-0 sm:hidden transition-transform duration-300 bg-surface dark:bg-surface-dark ${
           hidden ? 'translate-y-full' : ''
         }`}
       >

--- a/shared/ui/BottomSheet.tsx
+++ b/shared/ui/BottomSheet.tsx
@@ -44,7 +44,7 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-on-surface/50 dark:bg-on-surface-dark/50" />
         <Dialog.Content
-          className="fixed inset-x-0 bottom-0 rounded-t-2xl bg-surface-100 dark:bg-surface-800 shadow-lg transition-transform duration-300 motion-reduce:transition-none motion-reduce:duration-0"
+          className="fixed inset-x-0 bottom-0 rounded-t-2xl bg-surface dark:bg-surface-dark shadow-lg transition-transform duration-300 motion-reduce:transition-none motion-reduce:duration-0"
           style={{ transform: `translateY(${drag}px)` }}
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}

--- a/shared/ui/CommentsDrawer.tsx
+++ b/shared/ui/CommentsDrawer.tsx
@@ -62,7 +62,7 @@ export const CommentsDrawer: React.FC<CommentsDrawerProps> = ({
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-on-surface/50 dark:bg-on-surface-dark/50" />
-        <Dialog.Content className="fixed inset-x-0 bottom-0 flex max-h-[70vh] flex-col rounded-t-md bg-surface-100 dark:bg-surface-800 md:top-0 md:max-h-none md:h-screen">
+        <Dialog.Content className="fixed inset-x-0 bottom-0 flex max-h-[70vh] flex-col rounded-t-md bg-surface dark:bg-surface-dark md:top-0 md:max-h-none md:h-screen">
           <Dialog.Title className="p-4 text-lg font-semibold">
             Comments
           </Dialog.Title>

--- a/shared/ui/FabRecord.tsx
+++ b/shared/ui/FabRecord.tsx
@@ -55,7 +55,7 @@ const FabRecord: React.FC<FabRecordProps> = ({ className }) => {
         onTouchEnd={endPress}
         onMouseLeave={endPress}
         aria-label="Record"
-        className={`${positionClass} z-50 flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-r from-primary to-primary-light drop-shadow-lg motion-safe:hover:scale-105 sm:hidden`}
+        className={`${positionClass} z-50 flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-r from-primary to-secondary drop-shadow-lg motion-safe:hover:scale-105 sm:hidden`}
       >
         +
       </button>

--- a/shared/ui/Nav.tsx
+++ b/shared/ui/Nav.tsx
@@ -12,7 +12,7 @@ export const Nav: React.FC = () => {
   const [open, setOpen] = React.useState(false);
 
   return (
-    <header className="sticky top-0 z-10 flex items-center justify-between bg-subtleBg dark:bg-surface-800 p-2 shadow text-gray-900 dark:text-gray-100">
+    <header className="sticky top-0 z-10 flex items-center justify-between bg-surface dark:bg-surface-dark p-2 shadow text-gray-900 dark:text-gray-100">
       <div className="flex items-center gap-2 font-bold">
         <img src="/logo.svg" alt="CashuCast logo" className="h-6 w-6" />
         CashuCast
@@ -22,7 +22,7 @@ export const Nav: React.FC = () => {
         <ToggleDarkMode />
         <button
           onClick={() => setOpen(true)}
-          className="rounded bg-subtleBg dark:bg-surface-800 px-2 py-1 text-gray-900 dark:text-gray-100 min-tap"
+          className="rounded bg-surface dark:bg-surface-dark px-2 py-1 text-gray-900 dark:text-gray-100 min-tap"
         >
           Wallet
         </button>

--- a/shared/ui/PostMenu.tsx
+++ b/shared/ui/PostMenu.tsx
@@ -48,16 +48,16 @@ export const PostMenu: React.FC<PostMenuProps> = ({
         ⋮
       </button>
       {isOpen && (
-        <div className="absolute right-0 z-10 mt-2 w-40 rounded-md bg-surface-100 dark:bg-surface-800 shadow-lg ring-1 ring-black/5">
+        <div className="absolute right-0 z-10 mt-2 w-40 rounded-md bg-surface dark:bg-surface-dark shadow-lg ring-1 ring-black/5">
           <div className="py-1">
             <button
-              className="block w-full px-4 py-2 text-left text-sm hover:bg-subtleBg min-h-11"
+              className="block w-full px-4 py-2 text-left text-sm hover:bg-surface dark:hover:bg-surface-dark min-h-11"
               onClick={() => setReportOpen(true)}
             >
               Report
             </button>
             <button
-              className="block w-full px-4 py-2 text-left text-sm hover:bg-subtleBg min-h-11"
+              className="block w-full px-4 py-2 text-left text-sm hover:bg-surface dark:hover:bg-surface-dark min-h-11"
               onClick={handleBlock}
             >
               Block author
@@ -70,7 +70,7 @@ export const PostMenu: React.FC<PostMenuProps> = ({
           {reasons.map((r) => (
             <button
               key={r}
-              className="block w-full rounded p-2 text-left hover:bg-subtleBg min-h-11"
+              className="block w-full rounded p-2 text-left hover:bg-surface dark:hover:bg-surface-dark min-h-11"
               onClick={() => handleReport(r)}
             >
               {r}

--- a/shared/ui/Profile.tsx
+++ b/shared/ui/Profile.tsx
@@ -34,7 +34,7 @@ export const Profile: React.FC<ProfileProps> = ({
   return (
     <div className="flex flex-col gap-4 p-4">
       {blocked && (
-        <div className="rounded bg-subtleBg p-2 text-center text-sm text-gray-700">
+        <div className="rounded bg-surface dark:bg-surface-dark p-2 text-center text-sm text-gray-700">
           You have blocked this user.
         </div>
       )}

--- a/shared/ui/PublishBtn.tsx
+++ b/shared/ui/PublishBtn.tsx
@@ -26,7 +26,7 @@ export const PublishBtn: React.FC<PublishBtnProps> = ({ magnet, onPublish }) => 
       <button
         disabled={!magnet}
         onClick={handleClick}
-        className="px-4 py-2 bg-primary rounded disabled:bg-surface-100 dark:disabled:bg-surface-800 min-tap"
+        className="px-4 py-2 bg-primary rounded disabled:bg-surface dark:disabled:bg-surface-dark min-tap"
       >
         Publish
       </button>

--- a/shared/ui/QuotaBar.tsx
+++ b/shared/ui/QuotaBar.tsx
@@ -24,7 +24,7 @@ export const QuotaBar: React.FC = () => {
 
   return (
     <div className="space-y-1">
-      <div className="h-2 w-full bg-subtleBg rounded">
+      <div className="h-2 w-full bg-surface dark:bg-surface-dark rounded">
         <div
           className="h-2 bg-green-500 rounded"
           style={{ width: `${pct}%` }}

--- a/shared/ui/SkeletonLoader.test.tsx
+++ b/shared/ui/SkeletonLoader.test.tsx
@@ -13,7 +13,7 @@ describe('SkeletonLoader', () => {
     vi.resetModules();
     const { SkeletonLoader } = await import('./SkeletonLoader');
     const html = renderToStaticMarkup(<SkeletonLoader />);
-    expect(html).toContain('bg-subtleBg');
+    expect(html).toContain('bg-surface');
     expect(html).toContain('bg-gradient-to-r');
     expect(html).toContain('animate-skeleton-shimmer');
   });

--- a/shared/ui/SkeletonLoader.tsx
+++ b/shared/ui/SkeletonLoader.tsx
@@ -14,7 +14,7 @@ export interface SkeletonLoaderProps {
  */
 export const SkeletonLoader: React.FC<SkeletonLoaderProps> = ({ className }) => {
   return (
-    <div className={`relative overflow-hidden bg-subtleBg ${className ?? ''}`}>
+    <div className={`relative overflow-hidden bg-surface dark:bg-surface-dark ${className ?? ''}`}>
       <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200 animate-skeleton-shimmer" />
     </div>
   );

--- a/shared/ui/Stepper.tsx
+++ b/shared/ui/Stepper.tsx
@@ -43,7 +43,7 @@ export const Stepper: React.FC = () => {
         <Dialog.Overlay className="fixed inset-0 bg-on-surface/50 dark:bg-on-surface-dark/50" />
         <Dialog.Content
           aria-modal="true"
-          className="fixed left-1/2 top-1/2 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded bg-surface-100 dark:bg-surface-800 text-on-surface dark:text-on-surface-dark p-4 sm:p-6 md:p-8 mx-4 sm:mx-0 focus:outline-none"
+          className="fixed left-1/2 top-1/2 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded bg-surface dark:bg-surface-dark text-on-surface dark:text-on-surface-dark p-4 sm:p-6 md:p-8 mx-4 sm:mx-0 focus:outline-none"
         >
           <div
             role="progressbar"

--- a/shared/ui/Timeline.tsx
+++ b/shared/ui/Timeline.tsx
@@ -97,8 +97,8 @@ export const Timeline: React.FC = () => {
             </SwipeContainer>
           )}
         </div>
-        <div className="pointer-events-none fixed inset-y-0 left-0 hidden w-1/4 bg-subtleBg/40 backdrop-blur lg:block" />
-        <div className="pointer-events-none fixed inset-y-0 right-0 hidden w-1/4 bg-subtleBg/40 backdrop-blur lg:block" />
+        <div className="pointer-events-none fixed inset-y-0 left-0 hidden w-1/4 bg-surface/40 dark:bg-surface-dark/40 backdrop-blur lg:block" />
+        <div className="pointer-events-none fixed inset-y-0 right-0 hidden w-1/4 bg-surface/40 dark:bg-surface-dark/40 backdrop-blur lg:block" />
       </div>
       <BottomNav />
     </div>

--- a/shared/ui/TimelineCard.tsx
+++ b/shared/ui/TimelineCard.tsx
@@ -102,7 +102,7 @@ export const TimelineCard: React.FC<TimelineCardProps> = ({
               <Avatar name={name} url={avatarUrl} size={32} />
               <span className="font-semibold">{name}</span>
               {isModerator && reports > 0 && (
-                <span className="rounded-full bg-subtleBg/80 px-2 py-1 text-xs text-on-surface dark:text-on-surface-dark">
+                <span className="rounded-full bg-surface/80 dark:bg-surface-dark/80 px-2 py-1 text-xs text-on-surface dark:text-on-surface-dark">
                   ⚑ {reports}
                 </span>
               )}

--- a/shared/ui/ToggleDarkMode.tsx
+++ b/shared/ui/ToggleDarkMode.tsx
@@ -32,7 +32,7 @@ export const ToggleDarkMode: React.FC<React.ButtonHTMLAttributes<HTMLButtonEleme
         props.onClick?.(e);
         setDark((d) => !d);
       }}
-      className={`px-2 py-1 rounded bg-subtleBg text-gray-900 dark:bg-surface-800 dark:text-gray-100 min-tap ${
+      className={`px-2 py-1 rounded bg-surface text-gray-900 dark:bg-surface-dark dark:text-gray-100 min-tap ${
         props.className ?? ''
       }`}
     >

--- a/shared/ui/TranscodeModal.tsx
+++ b/shared/ui/TranscodeModal.tsx
@@ -94,9 +94,9 @@ export const TranscodeModal: React.FC<TranscodeModalProps> = ({
       <Dialog.Root open={open}>
         <Dialog.Portal>
           <Dialog.Overlay className="fixed inset-0 bg-on-surface/50 dark:bg-on-surface-dark/50" />
-          <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-surface-100 dark:bg-surface-800 text-on-surface dark:text-on-surface-dark p-4 rounded shadow">
+          <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-surface dark:bg-surface-dark text-on-surface dark:text-on-surface-dark p-4 rounded shadow">
             <Dialog.Title>Transcoding</Dialog.Title>
-            <div className="w-64 bg-subtleBg h-2 mt-2">
+            <div className="w-64 bg-surface dark:bg-surface-dark h-2 mt-2">
               <div className="bg-primary h-2" style={{ width: `${progress}%` }} />
             </div>
             <p className="mt-2 text-center">{progress}%</p>

--- a/shared/ui/VideoPlayer.test.tsx
+++ b/shared/ui/VideoPlayer.test.tsx
@@ -25,7 +25,7 @@ describe('VideoPlayer', () => {
     const html = renderToStaticMarkup(
       <VideoPlayer magnet="magnet:?xt=urn:btih:test" />
     );
-    expect(html).toContain('bg-subtleBg');
+    expect(html).toContain('bg-surface');
   });
 
   it('renders a video element once the blob URL resolves', async () => {

--- a/shared/ui/VideoPlayer.tsx
+++ b/shared/ui/VideoPlayer.tsx
@@ -51,7 +51,7 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({ magnet, postId }) => {
 
   if (src === '') {
     return (
-      <div className="flex h-full w-full items-center justify-center bg-subtleBg text-sm">
+      <div className="flex h-full w-full items-center justify-center bg-surface dark:bg-surface-dark text-sm">
         Failed to load video
       </div>
     );

--- a/shared/ui/WalletModal.tsx
+++ b/shared/ui/WalletModal.tsx
@@ -26,7 +26,7 @@ export const WalletModal: React.FC<WalletModalProps> = ({ open, onOpenChange }) 
           <button
             onClick={() => onOpenChange(false)}
             aria-label="Close wallet"
-            className="rounded bg-subtleBg px-2 py-1 min-tap"
+            className="rounded bg-surface dark:bg-surface-dark px-2 py-1 min-tap"
           >
             Close
           </button>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -14,13 +14,16 @@ module.exports = {
     },
     extend: {
       colors: {
-        primary: '#FF0759', /* TikTok hot-pink */
-        'primary-light': '#FF8A90',
-        'surface-100': '#FFFFFF',
-        'surface-800': '#121212',
-        'on-surface': '#000000',
-        'on-surface-dark': '#FFFFFF',
-        subtleBg: '#1F1F1F',
+        // Material 3 color roles: https://m3.material.io/styles/color/roles
+        primary: '#6750A4', // Primary https://m3.material.io/styles/color/roles#primary
+        secondary: '#625B71', // Secondary https://m3.material.io/styles/color/roles#secondary
+        background: '#FFFBFE', // Background https://m3.material.io/styles/color/roles#background
+        'background-dark': '#1C1B1F', // Background (Dark)
+        surface: '#FFFBFE', // Surface https://m3.material.io/styles/color/roles#surface
+        'surface-dark': '#1C1B1F', // Surface (Dark)
+        'on-surface': '#1C1B1F', // On Surface https://m3.material.io/styles/color/roles#on-surface
+        'on-surface-dark': '#E6E1E5', // On Surface (Dark)
+        error: '#B3261E', // Error https://m3.material.io/styles/color/roles#error
       },
       transitionTimingFunction: {
         ez: 'cubic-bezier(0.25,0.1,0.25,1)',


### PR DESCRIPTION
## Summary
- replace custom colors with Material 3 primary, secondary, background, surface, and error tokens
- link Tailwind color config to Material 3 color roles
- update components to use the new tokens

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68925a3d82d88331bf7385aa74445d9e