### PR TITLE
feat(web): add bottom navigation

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,6 +7,7 @@ import { ROUTES } from './router';
 import { useProfile } from '../shared/store/profile';
 import Onboarding from './routes/Onboarding';
 import SearchBar from './components/SearchBar';
+import BottomNav from './components/BottomNav';
 
 export default function App() {
   const { profile } = useProfile();
@@ -46,6 +47,7 @@ export default function App() {
       {!hasProfile && <Onboarding />}
       <div id="app-container" hidden={!hasProfile}>
         {RouteComponent ? <RouteComponent /> : <div>Not Found</div>}
+        <BottomNav path={path} />
         <SearchBar />
       </div>
     </>

--- a/apps/web/src/components/BottomNav.tsx
+++ b/apps/web/src/components/BottomNav.tsx
@@ -1,0 +1,46 @@
+/*
+ * Licensed under GPL-3.0-or-later
+ * Bottom navigation for app pages using MUI BottomNavigation.
+ * Material 3 spec: https://m3.material.io/components/navigation-bar/overview
+ * MUI docs: https://mui.com/material-ui/react-bottom-navigation/
+ */
+import React from 'react';
+import BottomNavigation from '@mui/material/BottomNavigation';
+import BottomNavigationAction from '@mui/material/BottomNavigationAction';
+import HomeIcon from '@mui/icons-material/Home';
+import TravelExploreIcon from '@mui/icons-material/TravelExplore';
+import VideocamIcon from '@mui/icons-material/Videocam';
+import SettingsIcon from '@mui/icons-material/Settings';
+
+interface Props {
+  path: string;
+}
+
+export default function BottomNav({ path }: Props) {
+  const normalizedPath = path === '/' ? '/compose' : path;
+
+  const handleChange = (
+    _event: React.SyntheticEvent,
+    newValue: string,
+  ) => {
+    if (newValue !== normalizedPath) {
+      window.history.pushState(null, '', newValue);
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    }
+  };
+
+  return (
+    <BottomNavigation
+      value={normalizedPath}
+      onChange={handleChange}
+      showLabels
+      className="fixed bottom-0 left-0 right-0 border-t"
+    >
+      <BottomNavigationAction label="Compose" value="/compose" icon={<HomeIcon />} />
+      <BottomNavigationAction label="Discover" value="/discover" icon={<TravelExploreIcon />} />
+      <BottomNavigationAction label="Record" value="/record" icon={<VideocamIcon />} />
+      <BottomNavigationAction label="Settings" value="/settings" icon={<SettingsIcon />} />
+    </BottomNavigation>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add MUI-based BottomNav with links to Compose, Discover, Record and Settings
- wire navigation into App component

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68926091a1b08331b6ed83394eb20870