### PR TITLE
feat: use mui backdrop for blur overlay

### DIFF
--- a/shared/ui/BlurOverlay.tsx
+++ b/shared/ui/BlurOverlay.tsx
@@ -1,27 +1,47 @@
 /*
  * Licensed under GPL-3.0-or-later
  * React component for BlurOverlay.
+ *
+ * Material 3 scrim guidance:
+ * https://m3.material.io/styles/scrim/overview
+ * MUI Backdrop docs:
+ * https://mui.com/material-ui/react-backdrop/
  */
 import React from 'react';
+import Backdrop, { BackdropProps } from '@mui/material/Backdrop';
+import { useTheme } from '@mui/material/styles';
 
-export interface BlurOverlayProps extends React.HTMLAttributes<HTMLDivElement> {
-  className?: string;
-}
+export type BlurOverlayProps = BackdropProps;
 
 /**
  * BlurOverlay renders a blurred overlay covering its parent. Useful for
  * hiding sensitive content until user interaction.
  */
 export const BlurOverlay: React.FC<BlurOverlayProps> = ({
-  className = '',
+  className,
   children,
+  open = true,
+  sx,
   ...props
-}) => (
-  <div
-    {...props}
-    className={`absolute inset-0 flex items-center justify-center bg-black/60 backdrop-blur-sm ${className}`}
-  >
-    {children}
-  </div>
-);
+}) => {
+  const theme = useTheme();
+  return (
+    <Backdrop
+      {...props}
+      open={open}
+      className={className}
+      sx={[
+        {
+          position: 'absolute',
+          inset: 0,
+          backgroundColor: `rgba(${theme.vars?.palette.background.defaultChannel ?? '0 0 0'} / 0.6)`,
+          backdropFilter: 'blur(4px)',
+        },
+        ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
+      ]}
+    >
+      {children}
+    </Backdrop>
+  );
+};
 


### PR DESCRIPTION
## Summary
- replace custom overlay with MUI Backdrop component
- add Material 3 and MUI Backdrop references

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6892608f1e708331893a515b8331fd9e