### PR TITLE
refactor: use MUI button for backup seed

### DIFF
--- a/shared/ui/BackupSeedBtn.tsx
+++ b/shared/ui/BackupSeedBtn.tsx
@@ -1,11 +1,15 @@
 /*
  * Licensed under GPL-3.0-or-later
  * React component for BackupSeedBtn.
+ *
+ * Material 3 button spec: https://m3.material.io/components/buttons/overview
+ * MUI Button docs: https://mui.com/material-ui/react-button/
  */
 import React from 'react';
+import Button from '@mui/material/Button';
 
 /** Button to export wallet seed as a text file. */
-export const BackupSeedBtn: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = (
+export const BackupSeedBtn: React.FC<React.ComponentProps<typeof Button>> = (
   props,
 ) => {
   const handleClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
@@ -22,12 +26,14 @@ export const BackupSeedBtn: React.FC<React.ButtonHTMLAttributes<HTMLButtonElemen
   };
 
   return (
-    <button
+    <Button
       {...props}
+      variant="contained"
+      color="success"
       onClick={handleClick}
-      className={`px-3 py-1 bg-green-600 rounded min-tap ${props.className ?? ''}`}
+      className={`min-tap ${props.className ?? ''}`}
     >
       Backup Seed
-    </button>
+    </Button>
   );
 };


### PR DESCRIPTION
## Summary
- replace manual backup seed button with MUI `Button`
- add comment linking Material 3 button spec and MUI Button docs

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689262d53928833192cba6ab8e40b731