### PR TITLE
feat: style follow button with MUI

### DIFF
--- a/shared/ui/FollowBtn.tsx
+++ b/shared/ui/FollowBtn.tsx
@@ -3,6 +3,7 @@
  * React component for FollowBtn.
  */
 import React from 'react';
+import Button from '@mui/material/Button';
 import { useSocialStore } from './socialStore';
 
 export interface FollowBtnProps {
@@ -11,17 +12,23 @@ export interface FollowBtnProps {
 
 /**
  * Button to follow or unfollow a creator.
+ *
+ * Follows Material 3 button guidance and MUI implementation:
+ * https://m3.material.io/components/buttons
+ * https://mui.com/material-ui/react-button/
  */
 export const FollowBtn: React.FC<FollowBtnProps> = ({ creatorId }) => {
   const isFollowing = useSocialStore((s) => s.creators[creatorId]?.isFollowing ?? false);
   const toggleFollow = useSocialStore((s) => s.toggleFollow);
 
   return (
-    <button
-      className="px-3 py-1 rounded bg-primary text-sm min-tap"
+    <Button
+      variant={isFollowing ? 'outlined' : 'contained'}
+      size="small"
       onClick={() => void toggleFollow(creatorId)}
+      sx={{ textTransform: 'none' }}
     >
       {isFollowing ? 'Unfollow' : 'Follow'}
-    </button>
+    </Button>
   );
 };


### PR DESCRIPTION
## Summary
- refactor FollowBtn to use MUI Button component
- toggle outlined/contained variants for follow/unfollow state
- document material 3 and MUI button reference links

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6892660a12008331b84d2d7d2247ac02