### PR TITLE
chore: use MUI drawer for comments

### DIFF
--- a/apps/web/src/components/CommentsDrawer.tsx
+++ b/apps/web/src/components/CommentsDrawer.tsx
@@ -3,12 +3,13 @@
  * React component for CommentsDrawer.
  */
 import React from 'react';
-import * as Dialog from '@radix-ui/react-dialog';
+import Drawer from '@mui/material/Drawer';
 import type { createRPCClient } from '../../shared/rpc';
 
-// Radix Dialog; 70 vh on phones, 100 vh desktop.
-// Shows existing comments via worker-ssb query.
-// Input at bottom, optimistic append then publish.
+// Material 3 navigation drawer spec:
+// https://m3.material.io/components/navigation-drawer/overview
+// MUI Drawer docs: https://mui.com/material-ui/react-drawer/
+// Drawer opens from bottom; 70 vh on phones, full height on desktop.
 
 interface CommentsDrawerProps {
   postId: string;
@@ -49,43 +50,50 @@ export const CommentsDrawer: React.FC<CommentsDrawerProps> = ({
   };
 
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-on-surface/50 dark:bg-on-surface-dark/50" />
-        <Dialog.Content className="fixed inset-x-0 bottom-0 flex max-h-[70vh] flex-col rounded-t-md bg-surface dark:bg-surface-dark md:top-0 md:max-h-none md:h-screen">
-          <Dialog.Title className="p-4 text-lg font-semibold">Comments</Dialog.Title>
-          <div className="flex-1 overflow-y-auto p-4 space-y-2">
-            {comments.map((c, i) => (
-              <p key={i} className="text-sm">
-                {c}
-              </p>
-            ))}
-            {comments.length === 0 && (
-              <p className="text-sm text-gray-500">No comments yet.</p>
-            )}
-          </div>
-          <form onSubmit={handleSubmit} className="flex gap-2 border-t p-4">
-            <label htmlFor="comment" className="sr-only">
-              Add a comment
-            </label>
-            <input
-              id="comment"
-              name="comment"
-              className="flex-1 rounded border px-2 py-1"
-              placeholder="Add a comment..."
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-            />
-            <button
-              type="submit"
-              className="rounded bg-purple-600 px-4 py-1 min-tap"
-            >
-              Send
-            </button>
-          </form>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+    <Drawer
+      anchor="bottom"
+      open={open}
+      onClose={() => onOpenChange(false)}
+      ModalProps={{ keepMounted: true }}
+      PaperProps={{
+        className:
+          'flex h-[70vh] flex-col rounded-t-md bg-surface dark:bg-surface-dark md:h-screen',
+      }}
+      BackdropProps={{
+        className: 'bg-on-surface/50 dark:bg-on-surface-dark/50',
+      }}
+    >
+      <h2 className="p-4 text-lg font-semibold">Comments</h2>
+      <div className="flex-1 overflow-y-auto p-4 space-y-2">
+        {comments.map((c, i) => (
+          <p key={i} className="text-sm">
+            {c}
+          </p>
+        ))}
+        {comments.length === 0 && (
+          <p className="text-sm text-gray-500">No comments yet.</p>
+        )}
+      </div>
+      <form onSubmit={handleSubmit} className="flex gap-2 border-t p-4">
+        <label htmlFor="comment" className="sr-only">
+          Add a comment
+        </label>
+        <input
+          id="comment"
+          name="comment"
+          className="flex-1 rounded border px-2 py-1"
+          placeholder="Add a comment..."
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="rounded bg-purple-600 px-4 py-1 min-tap"
+        >
+          Send
+        </button>
+      </form>
+    </Drawer>
   );
 };
 

--- a/shared/ui/CommentsDrawer.tsx
+++ b/shared/ui/CommentsDrawer.tsx
@@ -3,7 +3,7 @@
  * React component for CommentsDrawer.
  */
 import React from 'react';
-import * as Dialog from '@radix-ui/react-dialog';
+import Drawer from '@mui/material/Drawer';
 import { createRPCClient } from '../rpc';
 
 interface CommentsDrawerProps {
@@ -13,8 +13,11 @@ interface CommentsDrawerProps {
 }
 
 /**
- * Minimal comments drawer used by TimelineCard. Currently stores comments
- * locally and exposes an input for new comments.
+ * Minimal comments drawer used by TimelineCard. Uses MUI Drawer per Material 3
+ * navigation drawer guidance.
+ * https://m3.material.io/components/navigation-drawer/overview
+ * MUI Drawer docs: https://mui.com/material-ui/react-drawer/
+ * Stores comments locally and exposes an input for new comments.
  */
 export const CommentsDrawer: React.FC<CommentsDrawerProps> = ({
   postId,
@@ -59,45 +62,50 @@ export const CommentsDrawer: React.FC<CommentsDrawerProps> = ({
   };
 
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-on-surface/50 dark:bg-on-surface-dark/50" />
-        <Dialog.Content className="fixed inset-x-0 bottom-0 flex max-h-[70vh] flex-col rounded-t-md bg-surface dark:bg-surface-dark md:top-0 md:max-h-none md:h-screen">
-          <Dialog.Title className="p-4 text-lg font-semibold">
-            Comments
-          </Dialog.Title>
-          <div className="flex-1 overflow-y-auto p-4 space-y-2">
-            {comments.map((c, i) => (
-              <p key={i} className="text-sm">
-                {c}
-              </p>
-            ))}
-            {comments.length === 0 && (
-              <p className="text-sm text-gray-500">No comments yet.</p>
-            )}
-          </div>
-          <form onSubmit={handleSubmit} className="flex gap-2 border-t p-4">
-            <label htmlFor="comment" className="sr-only">
-              Add a comment
-            </label>
-            <input
-              id="comment"
-              name="comment"
-              className="flex-1 rounded border px-2 py-1"
-              placeholder="Add a comment..."
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-            />
-            <button
-              type="submit"
-              className="rounded bg-purple-600 px-4 py-1 min-tap"
-            >
-              Send
-            </button>
-          </form>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+    <Drawer
+      anchor="bottom"
+      open={open}
+      onClose={() => onOpenChange(false)}
+      ModalProps={{ keepMounted: true }}
+      PaperProps={{
+        className:
+          'flex h-[70vh] flex-col rounded-t-md bg-surface dark:bg-surface-dark md:h-screen',
+      }}
+      BackdropProps={{
+        className: 'bg-on-surface/50 dark:bg-on-surface-dark/50',
+      }}
+    >
+      <h2 className="p-4 text-lg font-semibold">Comments</h2>
+      <div className="flex-1 overflow-y-auto p-4 space-y-2">
+        {comments.map((c, i) => (
+          <p key={i} className="text-sm">
+            {c}
+          </p>
+        ))}
+        {comments.length === 0 && (
+          <p className="text-sm text-gray-500">No comments yet.</p>
+        )}
+      </div>
+      <form onSubmit={handleSubmit} className="flex gap-2 border-t p-4">
+        <label htmlFor="comment" className="sr-only">
+          Add a comment
+        </label>
+        <input
+          id="comment"
+          name="comment"
+          className="flex-1 rounded border px-2 py-1"
+          placeholder="Add a comment..."
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="rounded bg-purple-600 px-4 py-1 min-tap"
+        >
+          Send
+        </button>
+      </form>
+    </Drawer>
   );
 };
 


### PR DESCRIPTION
## Summary
- swap Radix dialog for MUI Drawer in comments UI
- document Material 3 navigation drawer spec and MUI Drawer docs

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689266061bf48331a1e7bff898f2f2ad