### PR TITLE
feat: add top navigation bar

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { ROUTES } from './router';
 import { useProfile } from '../shared/store/profile';
 import Onboarding from './routes/Onboarding';
-import SearchBar from './components/SearchBar';
+import TopNav from './components/TopNav';
 import BottomNav from './components/BottomNav';
 
 export default function App() {
@@ -46,9 +46,9 @@ export default function App() {
     <>
       {!hasProfile && <Onboarding />}
       <div id="app-container" hidden={!hasProfile}>
+        <TopNav />
         {RouteComponent ? <RouteComponent /> : <div>Not Found</div>}
         <BottomNav path={path} />
-        <SearchBar />
       </div>
     </>
   );

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -18,7 +18,7 @@ import type { Post } from '../../shared/types';
  * - `q`: the current search query.
  * - `setOpen`, `setQ`, `setResults`: update helpers for the store.
  *
- * @returns Fixed-position JSX that shows an input when open or a button when collapsed.
+ * @returns JSX that shows an input when open or a button when collapsed.
  */
 export default function SearchBar() {
   const { open, q, setOpen, setQ, setResults } = useSearch();
@@ -99,7 +99,7 @@ export default function SearchBar() {
   }, [q, setResults]);
 
   return (
-    <div ref={containerRef} className="fixed top-2 right-2 z-50">
+    <div ref={containerRef} className="ml-auto">
       {open ? (
         <>
           <label htmlFor="search" className="sr-only">

--- a/apps/web/src/components/TopNav.test.tsx
+++ b/apps/web/src/components/TopNav.test.tsx
@@ -1,0 +1,17 @@
+/* @vitest-environment jsdom */
+/*
+ * Licensed under GPL-3.0-or-later
+ * Test suite for TopNav.
+ */
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import TopNav from './TopNav';
+
+describe('TopNav', () => {
+  it('renders app title', () => {
+    const html = renderToString(<TopNav />);
+    expect(html).toContain('CashuCast');
+  });
+});
+

--- a/apps/web/src/components/TopNav.tsx
+++ b/apps/web/src/components/TopNav.tsx
@@ -1,0 +1,25 @@
+/*
+ * Licensed under GPL-3.0-or-later
+ * Top navigation bar using MUI AppBar and Toolbar.
+ * Material 3 spec: https://m3.material.io/components/top-app-bar/overview
+ * MUI docs: https://mui.com/material-ui/react-app-bar/
+ */
+import React from 'react';
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import SearchBar from './SearchBar';
+
+export default function TopNav() {
+  return (
+    <AppBar position="static">
+      <Toolbar>
+        <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+          CashuCast
+        </Typography>
+        <SearchBar />
+      </Toolbar>
+    </AppBar>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add MUI AppBar/Toolbar-based top navigation with in-app search
- integrate the new nav into the main app layout
- refactor SearchBar for toolbar placement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892698170648331a46abb284d2fa435