### PR TITLE
feat(ui): add MUI select

### DIFF
--- a/shared/ui/MintPicker.tsx
+++ b/shared/ui/MintPicker.tsx
@@ -3,18 +3,46 @@
  * React component for MintPicker.
  */
 import React from 'react';
+import Select, { SelectProps } from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
 
-/** Simple mint picker placeholder component. */
-export const MintPicker: React.FC<
-  React.SelectHTMLAttributes<HTMLSelectElement>
-> = ({ className, children, ...props }) => {
+/**
+ * Selection component styled with MUI theme tokens.
+ * Material 3 selection menu guidelines: https://m3.material.io/components/menus/overview
+ * MUI Select component docs: https://mui.com/material-ui/react-select/
+ */
+export const MintPicker: React.FC<SelectProps<string>> = ({
+  value,
+  defaultValue = '',
+  children,
+  sx,
+  ...props
+}) => {
+  const selectProps =
+    value !== undefined ? { value } : { defaultValue };
+
   return (
-    <select
+    <Select
+      displayEmpty
+      fullWidth
+      {...selectProps}
       {...props}
-      className={`w-full p-2 border rounded ${className ?? ''}`}
+      sx={{
+        bgcolor: 'background.paper',
+        color: 'text.primary',
+        '& .MuiOutlinedInput-notchedOutline': {
+          borderColor: 'primary.main',
+        },
+        '&:hover .MuiOutlinedInput-notchedOutline': {
+          borderColor: 'secondary.main',
+        },
+        ...sx,
+      }}
     >
-      <option value="">Default Mint</option>
+      <MenuItem value="">
+        <em>Default Mint</em>
+      </MenuItem>
       {children}
-    </select>
+    </Select>
   );
 };

--- a/shared/ui/MintSelect.tsx
+++ b/shared/ui/MintSelect.tsx
@@ -28,7 +28,7 @@ export const MintSelect: React.FC<MintSelectProps> = ({ onNext }) => {
       <h2 className="mb-2 text-lg font-semibold">Select Default Mint</h2>
       <MintPicker
         value={mint}
-        onChange={(e) => setMint(e.target.value)}
+        onChange={(e) => setMint(e.target.value as string)}
         autoFocus
       />
       <button


### PR DESCRIPTION
## Summary
- refactor MintPicker to use MUI Select styled with theme tokens
- document Material 3 selection menu and MUI Select references
- adjust MintSelect handler for MUI Select change events

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6892697dade08331a285ab4855fb883f