### PR TITLE
refactor: replace mint picker with MUI Select

### DIFF
--- a/shared/ui/MintPicker.tsx
+++ b/shared/ui/MintPicker.tsx
@@ -3,18 +3,28 @@
  * React component for MintPicker.
  */
 import React from 'react';
+import Select, { SelectProps } from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
 
-/** Simple mint picker placeholder component. */
-export const MintPicker: React.FC<
-  React.SelectHTMLAttributes<HTMLSelectElement>
-> = ({ className, children, ...props }) => {
-  return (
-    <select
+// Material 3 menu spec: https://m3.material.io/components/menus/overview
+// MUI Select docs: https://mui.com/material-ui/api/select/
+
+export type MintPickerProps = SelectProps<string>;
+
+export const MintPicker = React.forwardRef<HTMLDivElement, MintPickerProps>(
+  ({ className, children, defaultValue = '', ...props }, ref) => (
+    <Select
       {...props}
-      className={`w-full p-2 border rounded ${className ?? ''}`}
+      ref={ref}
+      className={className}
+      defaultValue={defaultValue}
+      displayEmpty
+      fullWidth
     >
-      <option value="">Default Mint</option>
+      <MenuItem value="">Default Mint</MenuItem>
       {children}
-    </select>
-  );
-};
+    </Select>
+  ),
+);
+
+MintPicker.displayName = 'MintPicker';


### PR DESCRIPTION
## Summary
- refactor mint picker to use MUI `Select` and `MenuItem`
- reference Material 3 menu spec and MUI Select docs

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68926978d2f48331b9f367a5eff0b5bd